### PR TITLE
"macos" for CI builds?

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ matrix.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
       - name: Install Node.js dependencies
         run: yarn install --frozen-lockfile
       - name: Run ESLint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -2,7 +2,10 @@ name: ESLint
 on: push
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   publish:
     name: Install and publish
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ matrix.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
       - name: Install Node.js dependencies
         run: yarn install --frozen-lockfile
       - uses: expo/expo-github-action@v5

--- a/.github/workflows/publish-pr-review.yml
+++ b/.github/workflows/publish-pr-review.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ matrix.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - uses: expo/expo-github-action@v5
         with:

--- a/.github/workflows/publish-pr-review.yml
+++ b/.github/workflows/publish-pr-review.yml
@@ -3,7 +3,10 @@ on: [pull_request]
 jobs:
   publish:
     name: Install and publish
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,10 @@ name: Unit Tests
 on: push
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: ${{ matrix.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
       - name: Install Node.js dependencies
         run: yarn install --frozen-lockfile
       - name: Run unit tests


### PR DESCRIPTION
This is an attempt to fix a possible CI issue involving caching, and the architecture/os of the build runner

TODO: Verify what the _ideal_ OS is for CI builds.  ...it seems Github actions support macos.