### PR TITLE
Display SubTypeAccordions

### DIFF
--- a/src/components/CategorySelector/CategorySelector.js
+++ b/src/components/CategorySelector/CategorySelector.js
@@ -3,7 +3,7 @@ import {
   StyleSheet, Text, ScrollView,
 } from 'react-native';
 import { Button } from 'native-base';
-import { array, func, string } from 'prop-types';
+import { arrayOf, func, string } from 'prop-types';
 
 import Colors from '../../constants/Colors';
 import RESOURCE_TYPES from '../../resources/resourceTypes';
@@ -20,26 +20,31 @@ const CatalogScreen = ({ categories, selectedCategory, setSelectedCategory }) =>
     );
   };
 
+  CategoryButton.propTypes = {
+    category: string.isRequired,
+  };
+
   return (
     <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
       {categories.map((category) => {
         if (category !== 'Patient') {
           return <CategoryButton key={category} category={category} />;
         }
+        return null;
       })}
     </ScrollView>
   );
 };
 
 CatalogScreen.propTypes = {
-  categories: array.isRequired,
+  categories: arrayOf(string.isRequired).isRequired,
   selectedCategory: string,
   setSelectedCategory: func.isRequired,
-}
+};
 
 CatalogScreen.defaultProps = {
-  selectedCategory: null
-}
+  selectedCategory: null,
+};
 
 export default CatalogScreen;
 

--- a/src/components/CategorySelector/CategorySelector.js
+++ b/src/components/CategorySelector/CategorySelector.js
@@ -1,38 +1,45 @@
 import React from 'react';
 import {
-  StyleSheet, Text, View, ScrollView,
+  StyleSheet, Text, ScrollView,
 } from 'react-native';
+import { Button } from 'native-base';
+import { array, func, string } from 'prop-types';
 
-import { Button } from 'native-base'
+import Colors from '../../constants/Colors';
+import RESOURCE_TYPES from '../../resources/resourceTypes';
 
-import Colors from '../../constants/Colors'
-import RESOURCE_TYPES from '../../resources/resourceTypes'
-
-const CatalogScreen = ({categories, selectedCategory, setSelectedCategory}) => {
-  const CategoryButton = ({category}) => {
-    const categoryDisplay = RESOURCE_TYPES[category]
-    const buttonStyle = category === selectedCategory ? styles.buttonSelected : styles.button
-    const buttonTextStyle = category === selectedCategory ? styles.buttonSelectedText : null
+const CatalogScreen = ({ categories, selectedCategory, setSelectedCategory }) => {
+  const CategoryButton = ({ category }) => {
+    const categoryDisplay = RESOURCE_TYPES[category];
+    const buttonStyle = category === selectedCategory ? styles.buttonSelected : styles.button;
+    const buttonTextStyle = category === selectedCategory ? styles.buttonSelectedText : null;
     return (
       <Button style={buttonStyle} onPress={() => setSelectedCategory(category)}>
         <Text style={buttonTextStyle}>{categoryDisplay}</Text>
       </Button>
-    )
-  }
+    );
+  };
 
-  const scrubbedCategories = categories.filter(category => category !== "Patient" && category !== "Observation")
-
-  return(
+  return (
     <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
-      {scrubbedCategories.map(category => {
-        if (category !== "Patient") {
-          return <CategoryButton key={category} category={category} />
+      {categories.map((category) => {
+        if (category !== 'Patient') {
+          return <CategoryButton key={category} category={category} />;
         }
       })}
     </ScrollView>
-  )
+  );
+};
+
+CatalogScreen.propTypes = {
+  categories: array.isRequired,
+  selectedCategory: string,
+  setSelectedCategory: func.isRequired,
 }
 
+CatalogScreen.defaultProps = {
+  selectedCategory: null
+}
 
 export default CatalogScreen;
 
@@ -57,6 +64,6 @@ const styles = StyleSheet.create({
     borderRadius: 30,
   },
   buttonSelectedText: {
-    color: 'white'
-  }
+    color: 'white',
+  },
 });

--- a/src/components/CategorySelector/CategorySelector.js
+++ b/src/components/CategorySelector/CategorySelector.js
@@ -23,7 +23,7 @@ const CatalogScreen = ({categories, selectedCategory, setSelectedCategory}) => {
   const scrubbedCategories = categories.filter(category => category !== "Patient" && category !== "Observation")
 
   return(
-    <ScrollView style={styles.root} horizontal>
+    <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
       {scrubbedCategories.map(category => {
         if (category !== "Patient") {
           return <CategoryButton key={category} category={category} />
@@ -38,7 +38,7 @@ export default CatalogScreen;
 
 const styles = StyleSheet.create({
   root: {
-    backgroundColor: Colors.primaryLight,
+    backgroundColor: Colors.mediumgrey,
     borderColor: 'gray',
     marginTop: 20,
     flexDirection: 'row',

--- a/src/components/CategorySelector/CategorySelector.js
+++ b/src/components/CategorySelector/CategorySelector.js
@@ -3,46 +3,61 @@ import {
   StyleSheet, Text, View, ScrollView,
 } from 'react-native';
 
-const CatalogScreen = () => (
-  <ScrollView style={styles.root} horizontal>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-    <View style={styles.button}>
-      <Text style={styles.buttonText}>Category</Text>
-    </View>
-  </ScrollView>
-);
+import { Button } from 'native-base'
+
+import Colors from '../../constants/Colors'
+import RESOURCE_TYPES from '../../resources/resourceTypes'
+
+const CatalogScreen = ({categories, selectedCategory, setSelectedCategory}) => {
+  const CategoryButton = ({category}) => {
+    const categoryDisplay = RESOURCE_TYPES[category]
+    const buttonStyle = category === selectedCategory ? styles.buttonSelected : styles.button
+    const buttonTextStyle = category === selectedCategory ? styles.buttonSelectedText : null
+    return (
+      <Button style={buttonStyle} onPress={() => setSelectedCategory(category)}>
+        <Text style={buttonTextStyle}>{categoryDisplay}</Text>
+      </Button>
+    )
+  }
+
+  const scrubbedCategories = categories.filter(category => category !== "Patient" && category !== "Observation")
+
+  return(
+    <ScrollView style={styles.root} horizontal>
+      {scrubbedCategories.map(category => {
+        if (category !== "Patient") {
+          return <CategoryButton key={category} category={category} />
+        }
+      })}
+    </ScrollView>
+  )
+}
+
 
 export default CatalogScreen;
 
 const styles = StyleSheet.create({
   root: {
-    backgroundColor: 'lightgray',
-    borderWidth: 1,
+    backgroundColor: Colors.primaryLight,
     borderColor: 'gray',
     marginTop: 20,
     flexDirection: 'row',
     padding: 10,
   },
   button: {
-    padding: 10,
+    paddingHorizontal: 10,
+    marginHorizontal: 10,
+    backgroundColor: 'white',
+    borderRadius: 30,
+  },
+  buttonSelected: {
+    paddingHorizontal: 10,
     marginHorizontal: 10,
     borderWidth: 2,
-    borderColor: 'black',
-    backgroundColor: 'white',
-    borderRadius: 20,
+    backgroundColor: Colors.primary,
+    borderRadius: 30,
   },
+  buttonSelectedText: {
+    color: 'white'
+  }
 });

--- a/src/components/CategorySelector/CategorySelector.js
+++ b/src/components/CategorySelector/CategorySelector.js
@@ -53,7 +53,6 @@ const styles = StyleSheet.create({
   buttonSelected: {
     paddingHorizontal: 10,
     marginHorizontal: 10,
-    borderWidth: 2,
     backgroundColor: Colors.primary,
     borderRadius: 30,
   },

--- a/src/components/RecordCard/RecordCardsContainer.js
+++ b/src/components/RecordCard/RecordCardsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  StyleSheet, Text, View,
+  StyleSheet, View,
 } from 'react-native';
 import {connect} from 'react-redux'
 

--- a/src/components/RecordCard/RecordCardsContainer.js
+++ b/src/components/RecordCard/RecordCardsContainer.js
@@ -3,9 +3,8 @@ import {
   StyleSheet, Text, View,
 } from 'react-native';
 import {connect} from 'react-redux'
-import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
 
-import RecordCard from './RecordCard';
+import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
 
 const RecordCardsContainer = ({resourceIdsGroupedByType}) => {
   const selectedCategory = "Condition"
@@ -13,7 +12,6 @@ const RecordCardsContainer = ({resourceIdsGroupedByType}) => {
   
   return(
     <View style={styles.root}>
-      <Text>RecordCards Container</Text>
       <View style={styles.container}>
         {Object.keys(categorySubTypes).map(subType => {
           const resourcesIds = Array.from(categorySubTypes[subType])
@@ -34,10 +32,6 @@ export default connect(mapStateToProps, null)(RecordCardsContainer);
 const styles = StyleSheet.create({
   root: {
     width: '100%',
-    padding: 10,
-    backgroundColor: 'lightgray',
-    borderWidth: 1,
-    borderColor: 'gray',
     marginVertical: 20,
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/components/RecordCard/RecordCardsContainer.js
+++ b/src/components/RecordCard/RecordCardsContainer.js
@@ -2,25 +2,34 @@ import React from 'react';
 import {
   StyleSheet, Text, View,
 } from 'react-native';
+import {connect} from 'react-redux'
+import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
 
 import RecordCard from './RecordCard';
 
-const CatalogScreen = () => (
-  <View style={styles.root}>
-    <Text>RecordCards Container</Text>
-    <View style={styles.container}>
-      <RecordCard />
-      <RecordCard />
-      <RecordCard />
-      <RecordCard />
-      <RecordCard />
-      <RecordCard />
-      <RecordCard />
+const RecordCardsContainer = ({resourceIdsGroupedByType}) => {
+  const selectedCategory = "Condition"
+  const categorySubTypes = resourceIdsGroupedByType[selectedCategory]
+  
+  return(
+    <View style={styles.root}>
+      <Text>RecordCards Container</Text>
+      <View style={styles.container}>
+        {Object.keys(categorySubTypes).map(subType => {
+          const resourcesIds = Array.from(categorySubTypes[subType])
+          return (
+            <SubTypeAccordion subType={subType} resourcesIds={resourcesIds} />
+          )
+        })}
+      </View>
     </View>
-  </View>
-);
+)};
 
-export default CatalogScreen;
+const mapStateToProps = (state) => ({
+  resourceIdsGroupedByType: state.resourceIdsGroupedByType
+})
+
+export default connect(mapStateToProps, null)(RecordCardsContainer);
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/RecordCard/RecordCardsContainer.js
+++ b/src/components/RecordCard/RecordCardsContainer.js
@@ -6,8 +6,7 @@ import {connect} from 'react-redux'
 
 import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
 
-const RecordCardsContainer = ({resourceIdsGroupedByType}) => {
-  const selectedCategory = "Condition"
+const RecordCardsContainer = ({selectedCategory, resourceIdsGroupedByType}) => {
   const categorySubTypes = resourceIdsGroupedByType[selectedCategory]
   
   return(

--- a/src/components/RecordCard/RecordCardsContainer.js
+++ b/src/components/RecordCard/RecordCardsContainer.js
@@ -2,29 +2,30 @@ import React from 'react';
 import {
   StyleSheet, View,
 } from 'react-native';
-import {connect} from 'react-redux'
+import { connect } from 'react-redux';
 
 import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
 
-const RecordCardsContainer = ({selectedCategory, resourceIdsGroupedByType}) => {
-  const categorySubTypes = resourceIdsGroupedByType[selectedCategory]
-  
-  return(
+const RecordCardsContainer = ({ selectedCategory, resourceIdsGroupedByType }) => {
+  const categorySubTypes = resourceIdsGroupedByType[selectedCategory];
+
+  return (
     <View style={styles.root}>
       <View style={styles.container}>
-        {Object.keys(categorySubTypes).map(subType => {
-          const resourcesIds = Array.from(categorySubTypes[subType])
+        {Object.keys(categorySubTypes).map((subType) => {
+          const resourcesIds = Array.from(categorySubTypes[subType]);
           return (
             <SubTypeAccordion subType={subType} resourcesIds={resourcesIds} />
-          )
+          );
         })}
       </View>
     </View>
-)};
+  );
+};
 
 const mapStateToProps = (state) => ({
-  resourceIdsGroupedByType: state.resourceIdsGroupedByType
-})
+  resourceIdsGroupedByType: state.resourceIdsGroupedByType,
+});
 
 export default connect(mapStateToProps, null)(RecordCardsContainer);
 

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+
+const SubTypeAccordion = ({subType, resourcesIds}) => {
+  console.log('subType', subType)
+  console.log('resourcesIds', resourcesIds)
+  return (
+    <View>
+      <Text>{subType}</Text>
+    </View>
+  )
+}
+
+export default SubTypeAccordion
+
+const styles = StyleSheet.create({})

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import { Accordion, Icon} from "native-base";
+import { Accordion } from "native-base";
+import { Ionicons } from '@expo/vector-icons';
 
 import Colors from '../../constants/Colors'
 
@@ -21,9 +22,10 @@ const SubTypeAccordion = ({subType, resourcesIds}) => {
         <View style={{width: '80%'}}>
           <Text style={{color: 'white'}}>{item.title} [{item.content.length}]</Text>
         </View>
-        {expanded
-          ? <Icon style={{ fontSize: 18 }} name="remove-circle" />
-          : <Icon style={{ fontSize: 18 }} name="add-circle" />}
+        { expanded
+          ? <Ionicons name="caret-down" size={20} color='white' />
+          : <Ionicons name="caret-up" size={20} color='white' />
+        }
       </View>
     )
   }

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -16,9 +16,11 @@ const SubTypeAccordion = ({subType, resourcesIds}) => {
         padding: 10,
         justifyContent: "space-between",
         alignItems: "center" ,
-        backgroundColor: Colors.primary 
+        backgroundColor: Colors.primary,
       }} >
-        <Text style={{color: 'white'}}>{item.title}</Text>
+        <View style={{width: '80%'}}>
+          <Text style={{color: 'white'}}>{item.title} [{item.content.length}]</Text>
+        </View>
         {expanded
           ? <Icon style={{ fontSize: 18 }} name="remove-circle" />
           : <Icon style={{ fontSize: 18 }} name="add-circle" />}
@@ -27,7 +29,7 @@ const SubTypeAccordion = ({subType, resourcesIds}) => {
   }
 
   const renderContent = (item) => {
-    return item.content.map(resourceId => <View><Text>{resourceId}</Text></View>)
+    return item.content.map(resourceId => <View style={{backgroundColor: 'white', padding: 10}}><Text>{resourceId}</Text></View>)
   }
 
   return (
@@ -36,7 +38,7 @@ const SubTypeAccordion = ({subType, resourcesIds}) => {
         dataArray={dataArray}
         icon="add" 
         iconStyle={{ color: "green" }}
-        expanded={[0]}
+        expanded={[]}
         renderHeader={renderHeader}
         renderContent={renderContent}
       />

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,53 +1,55 @@
-import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
-import { Accordion } from "native-base";
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Accordion } from 'native-base';
 import { Ionicons } from '@expo/vector-icons';
 
-import Colors from '../../constants/Colors'
+import Colors from '../../constants/Colors';
 
-const SubTypeAccordion = ({subType, resourcesIds}) => {
+const SubTypeAccordion = ({ subType, resourcesIds }) => {
   const dataArray = [
-    {title: subType, content: resourcesIds},
-  ]
+    { title: subType, content: resourcesIds },
+  ];
 
-  const renderHeader = (item, expanded) => {
-    return (
-      <View style={{
-        flexDirection: "row",
-        padding: 10,
-        justifyContent: "space-between",
-        alignItems: "center" ,
-        backgroundColor: Colors.primary,
-      }} >
-        <View style={{width: '80%'}}>
-          <Text style={{color: 'white'}}>{item.title} [{item.content.length}]</Text>
-        </View>
-        { expanded
-          ? <Ionicons name="caret-down" size={20} color='white' />
-          : <Ionicons name="caret-up" size={20} color='white' />
-        }
+  const renderHeader = (item, expanded) => (
+    <View style={{
+      flexDirection: 'row',
+      padding: 10,
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      backgroundColor: Colors.primary,
+    }}
+    >
+      <View style={{ width: '80%' }}>
+        <Text style={{ color: 'white' }}>
+          {item.title}
+          {' '}
+          [
+          {item.content.length}
+          ]
+        </Text>
       </View>
-    )
-  }
+      { expanded
+        ? <Ionicons name="caret-down" size={20} color="white" />
+        : <Ionicons name="caret-up" size={20} color="white" />}
+    </View>
+  );
 
-  const renderContent = (item) => {
-    return item.content.map(resourceId => <View style={{backgroundColor: 'white', padding: 10}}><Text>{resourceId}</Text></View>)
-  }
+  const renderContent = (item) => item.content.map((resourceId) => <View style={{ backgroundColor: 'white', padding: 10 }}><Text>{resourceId}</Text></View>);
 
   return (
-    <View style={{marginBottom: 10}}>
-      <Accordion 
+    <View style={{ marginBottom: 10 }}>
+      <Accordion
         dataArray={dataArray}
-        icon="add" 
-        iconStyle={{ color: "green" }}
+        icon="add"
+        iconStyle={{ color: 'green' }}
         expanded={[]}
         renderHeader={renderHeader}
         renderContent={renderContent}
       />
     </View>
-  )
-}
+  );
+};
 
-export default SubTypeAccordion
+export default SubTypeAccordion;
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({});

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,31 +1,19 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { Accordion } from 'native-base';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 
+import { arrayOf, string } from 'prop-types';
 import Colors from '../../constants/Colors';
 
 const SubTypeAccordion = ({ subType, resourcesIds }) => {
-  const dataArray = [
-    { title: subType, content: resourcesIds },
-  ];
+  const dataArray = [{ title: subType, content: resourcesIds }];
 
   const renderHeader = (item, expanded) => (
-    <View style={{
-      flexDirection: 'row',
-      padding: 10,
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      backgroundColor: Colors.primary,
-    }}
-    >
-      <View style={{ width: '80%' }}>
-        <Text style={{ color: 'white' }}>
-          {item.title}
-          {' '}
-          [
-          {item.content.length}
-          ]
+    <View style={styles.header}>
+      <View style={styles.headerTextContainer}>
+        <Text style={styles.headerText}>
+          {`${item.title} [${item.content.length}]`}
         </Text>
       </View>
       { expanded
@@ -50,6 +38,25 @@ const SubTypeAccordion = ({ subType, resourcesIds }) => {
   );
 };
 
+SubTypeAccordion.propTypes = {
+  subType: string.isRequired,
+  resourcesIds: arrayOf(string.isRequired).isRequired,
+};
+
 export default SubTypeAccordion;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    padding: 10,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: Colors.primary,
+  },
+  headerTextContainer: {
+    width: '80%',
+  },
+  headerText: {
+    color: 'white',
+  },
+});

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,12 +1,45 @@
 import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
+import { Accordion, Icon} from "native-base";
+
+import Colors from '../../constants/Colors'
 
 const SubTypeAccordion = ({subType, resourcesIds}) => {
-  console.log('subType', subType)
-  console.log('resourcesIds', resourcesIds)
+  const dataArray = [
+    {title: subType, content: resourcesIds},
+  ]
+
+  const renderHeader = (item, expanded) => {
+    return (
+      <View style={{
+        flexDirection: "row",
+        padding: 10,
+        justifyContent: "space-between",
+        alignItems: "center" ,
+        backgroundColor: Colors.primary 
+      }} >
+        <Text style={{color: 'white'}}>{item.title}</Text>
+        {expanded
+          ? <Icon style={{ fontSize: 18 }} name="remove-circle" />
+          : <Icon style={{ fontSize: 18 }} name="add-circle" />}
+      </View>
+    )
+  }
+
+  const renderContent = (item) => {
+    return item.content.map(resourceId => <View><Text>{resourceId}</Text></View>)
+  }
+
   return (
-    <View>
-      <Text>{subType}</Text>
+    <View style={{marginBottom: 10}}>
+      <Accordion 
+        dataArray={dataArray}
+        icon="add" 
+        iconStyle={{ color: "green" }}
+        expanded={[0]}
+        renderHeader={renderHeader}
+        renderContent={renderContent}
+      />
     </View>
   )
 }

--- a/src/components/SubTypeAccordion/SubTypeAccordionsContainer.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordionsContainer.js
@@ -26,12 +26,12 @@ const SubTypeAccordionsContainer = ({ selectedCategory, resourceIdsGroupedByType
 
 SubTypeAccordionsContainer.propTypes = {
   selectedCategory: string,
-  resourceIdsGroupedByType: shape({}).isRequired
-}
+  resourceIdsGroupedByType: shape({}).isRequired,
+};
 
 SubTypeAccordionsContainer.defaultProps = {
-  selectedCategory: null
-}
+  selectedCategory: null,
+};
 
 const mapStateToProps = (state) => ({
   resourceIdsGroupedByType: state.resourceIdsGroupedByType,

--- a/src/components/SubTypeAccordion/SubTypeAccordionsContainer.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordionsContainer.js
@@ -3,10 +3,11 @@ import {
   StyleSheet, View,
 } from 'react-native';
 import { connect } from 'react-redux';
+import { string, shape } from 'prop-types';
 
-import SubTypeAccordion from '../SubTypeAccordion/SubTypeAccordion';
+import SubTypeAccordion from './SubTypeAccordion';
 
-const RecordCardsContainer = ({ selectedCategory, resourceIdsGroupedByType }) => {
+const SubTypeAccordionsContainer = ({ selectedCategory, resourceIdsGroupedByType }) => {
   const categorySubTypes = resourceIdsGroupedByType[selectedCategory];
 
   return (
@@ -23,11 +24,20 @@ const RecordCardsContainer = ({ selectedCategory, resourceIdsGroupedByType }) =>
   );
 };
 
+SubTypeAccordionsContainer.propTypes = {
+  selectedCategory: string,
+  resourceIdsGroupedByType: shape({}).isRequired
+}
+
+SubTypeAccordionsContainer.defaultProps = {
+  selectedCategory: null
+}
+
 const mapStateToProps = (state) => ({
   resourceIdsGroupedByType: state.resourceIdsGroupedByType,
 });
 
-export default connect(mapStateToProps, null)(RecordCardsContainer);
+export default connect(mapStateToProps, null)(SubTypeAccordionsContainer);
 
 const styles = StyleSheet.create({
   root: {

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -3,4 +3,5 @@ export default {
   primaryLight: '#c7d7f0',
   secondary: '#4a8fe4',
   lightgrey: '#c2c2c2',
+  mediumgrey: '#d9d9d9'
 };

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -4,5 +4,5 @@ export default {
   primaryDark: '#143263',
   secondary: '#4a8fe4',
   lightgrey: '#c2c2c2',
-  mediumgrey: '#d9d9d9'
+  mediumgrey: '#d9d9d9',
 };

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -1,5 +1,6 @@
 export default {
   primary: '#3477e3',
+  primaryLight: '#c7d7f0',
   secondary: '#4a8fe4',
   lightgrey: '#c2c2c2',
 };

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -1,6 +1,7 @@
 export default {
   primary: '#3477e3',
   primaryLight: '#c7d7f0',
+  primaryDark: '#143263',
   secondary: '#4a8fe4',
   lightgrey: '#c2c2c2',
   mediumgrey: '#d9d9d9'

--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Ionicons } from '@expo/vector-icons/'; // eslint-disable-line import/no-extraneous-dependencies
+import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 
 import LoginScreen from '../screens/LoginScreen';
 import SummaryScreen from '../screens/SummaryScreen';

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -56,14 +56,13 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
             acc[resourceType] = {};
           }
           if (!acc[resourceType][subType]) {
-            acc[resourceType][subType] = new Set()
-          } 
+            acc[resourceType][subType] = new Set();
+          }
           if (acc[resourceType][subType].has(resource.id)) {
             console.warn(`${resourceType}--${subType} already contains ${id}`); // eslint-disable-line no-console
           } else {
             acc[resourceType][subType].add(resource.id);
           }
-
         }
         return acc;
       }, {});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -28,7 +28,8 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
     case actionTypes.GROUP_BY_TYPE: {
       const { payload } = action;
       return Object.entries(payload).reduce((acc, [id, resource]) => {
-        let { resourceType, subType } = resource;
+        let { resourceType } = resource;
+        const { subType } = resource;
         if (resourceType === 'Observation') {
           const { code } = resource.category[0].coding[0];
           switch (code) {

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -28,7 +28,8 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
     case actionTypes.GROUP_BY_TYPE: {
       const { payload } = action;
       return Object.entries(payload).reduce((acc, [id, resource]) => {
-        let { resourceType } = resource;
+        let { resourceType, subType } = resource;
+        console.log('subType', subType)
         if (resourceType === 'Observation') {
           const { code } = resource.category[0].coding[0];
           switch (code) {
@@ -42,13 +43,29 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
             }
           }
         }
-        if (!acc[resourceType]) {
-          acc[resourceType] = new Set();
-        }
-        if (acc[resourceType].has(resource.id)) {
-          console.warn(`${resourceType} already contains ${id}`); // eslint-disable-line no-console
+        if (!subType) {
+          if (!acc[resourceType]) {
+            acc[resourceType] = new Set();
+          }
+          if (acc[resourceType].has(resource.id)) {
+            console.warn(`${resourceType} already contains ${id}`); // eslint-disable-line no-console
+          } else {
+            acc[resourceType].add(resource.id);
+          }
         } else {
-          acc[resourceType].add(resource.id);
+          if (!acc[resourceType]) {
+            acc[resourceType] = {};
+          }
+          else {
+            if (!acc[resourceType][subType]) {
+              acc[resourceType][subType] = new Set()
+            } 
+            if (acc[resourceType][subType].has(resource.id)) {
+              console.warn(`${resourceType}--${subType} already contains ${id}`); // eslint-disable-line no-console
+            } else {
+              acc[resourceType][subType].add(resource.id);
+            }
+          }
         }
         return acc;
       }, {});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -29,7 +29,6 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
       const { payload } = action;
       return Object.entries(payload).reduce((acc, [id, resource]) => {
         let { resourceType, subType } = resource;
-        console.log('subType', subType)
         if (resourceType === 'Observation') {
           const { code } = resource.category[0].coding[0];
           switch (code) {

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -55,16 +55,15 @@ export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, 
           if (!acc[resourceType]) {
             acc[resourceType] = {};
           }
-          else {
-            if (!acc[resourceType][subType]) {
-              acc[resourceType][subType] = new Set()
-            } 
-            if (acc[resourceType][subType].has(resource.id)) {
-              console.warn(`${resourceType}--${subType} already contains ${id}`); // eslint-disable-line no-console
-            } else {
-              acc[resourceType][subType].add(resource.id);
-            }
+          if (!acc[resourceType][subType]) {
+            acc[resourceType][subType] = new Set()
+          } 
+          if (acc[resourceType][subType].has(resource.id)) {
+            console.warn(`${resourceType}--${subType} already contains ${id}`); // eslint-disable-line no-console
+          } else {
+            acc[resourceType][subType].add(resource.id);
           }
+
         }
         return acc;
       }, {});

--- a/src/resources/fhirReader.js
+++ b/src/resources/fhirReader.js
@@ -2,7 +2,7 @@ import {
   format, parse, formatDuration, intervalToDuration,
 } from 'date-fns';
 
-const injectSubtype = (resource) => {
+const injectSubType = (resource) => {
   let subType
   switch (resource.resourceType) {
     case "Condition":
@@ -57,7 +57,7 @@ export const processBundle = (acc, resource, depth) => {
     if (acc[id]) {
       console.warn(`resource ${id} already exists.`); // eslint-disable-line no-console
     }
-    acc[id] = injectSubtype(resource);
+    acc[id] = injectSubType(resource);
   }
 };
 

--- a/src/resources/fhirReader.js
+++ b/src/resources/fhirReader.js
@@ -3,33 +3,33 @@ import {
 } from 'date-fns';
 
 const injectSubType = (resource) => {
-  let subType
+  let subType;
   switch (resource.resourceType) {
-    case "Condition":
-    case "DiagnosticReport":
-    case "Procedure":
-    case "Observation":
-      subType = resource.code?.text
-      break
-    case "Encounter":
-      subType = resource.type?.[0]?.text
-      break
-    case "Immunization":
-      subType = resource.vaccineCode?.text
-      break
-    case "MedicationRequest":
-      subType = resource.medicationCodeableConcept?.text
-      break
-    case "CarePlan":
-      subType = resource.category?.[0]?.text
-      break
+    case 'Condition':
+    case 'DiagnosticReport':
+    case 'Procedure':
+    case 'Observation':
+      subType = resource.code?.text;
+      break;
+    case 'Encounter':
+      subType = resource.type?.[0]?.text;
+      break;
+    case 'Immunization':
+      subType = resource.vaccineCode?.text;
+      break;
+    case 'MedicationRequest':
+      subType = resource.medicationCodeableConcept?.text;
+      break;
+    case 'CarePlan':
+      subType = resource.category?.[0]?.text;
+      break;
     default:
-      subType = null
-      break
+      subType = null;
+      break;
   }
-  
-  return {...resource, subType}
-}
+
+  return { ...resource, subType };
+};
 
 const MAX_DEPTH = 4;
 export const processBundle = (acc, resource, depth) => {

--- a/src/resources/fhirReader.js
+++ b/src/resources/fhirReader.js
@@ -2,6 +2,35 @@ import {
   format, parse, formatDuration, intervalToDuration,
 } from 'date-fns';
 
+const injectSubtype = (resource) => {
+  let subType
+  switch (resource.resourceType) {
+    case "Condition":
+    case "DiagnosticReport":
+    case "Procedure":
+    case "Observation":
+      subType = resource.code?.text
+      break
+    case "Encounter":
+      subType = resource.type?.[0]?.text
+      break
+    case "Immunization":
+      subType = resource.vaccineCode?.text
+      break
+    case "MedicationRequest":
+      subType = resource.medicationCodeableConcept?.text
+      break
+    case "CarePlan":
+      subType = resource.category?.[0]?.text
+      break
+    default:
+      subType = null
+      break
+  }
+  
+  return {...resource, subType}
+}
+
 const MAX_DEPTH = 4;
 export const processBundle = (acc, resource, depth) => {
   if (depth > MAX_DEPTH) {
@@ -28,7 +57,7 @@ export const processBundle = (acc, resource, depth) => {
     if (acc[id]) {
       console.warn(`resource ${id} already exists.`); // eslint-disable-line no-console
     }
-    acc[id] = resource;
+    acc[id] = injectSubtype(resource);
   }
 };
 

--- a/src/screens/CatalogScreen.js
+++ b/src/screens/CatalogScreen.js
@@ -24,9 +24,11 @@ const CatalogScreen = ({resourceIdsGroupedByType}) => {
             selectedCategory={selectedCategory} 
             setSelectedCategory={setSelectedCategory} 
           />
-          <RecordCardsContainer 
-            selectedCategory={selectedCategory} 
-          />
+          { selectedCategory && (
+            <RecordCardsContainer 
+              selectedCategory={selectedCategory} 
+            />
+          )}
         </ScrollView>
       </FilterDrawer>
     </SafeAreaView>

--- a/src/screens/CatalogScreen.js
+++ b/src/screens/CatalogScreen.js
@@ -1,8 +1,8 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import {
   StyleSheet, SafeAreaView, StatusBar, ScrollView,
 } from 'react-native';
-import {connect} from 'react-redux'
+import { connect } from 'react-redux';
 
 import TimelineWidget from '../components/Timeline/TimelineWidget';
 import CategorySelector from '../components/CategorySelector/CategorySelector';
@@ -10,34 +10,36 @@ import RecordCardsContainer from '../components/RecordCard/RecordCardsContainer'
 import Colors from '../constants/Colors';
 import FilterDrawer from '../components/FilterDrawer/FilterDrawer';
 
-const CatalogScreen = ({resourceIdsGroupedByType}) => {
-  const [selectedCategory, setSelectedCategory] = useState(null)
+const CatalogScreen = ({ resourceIdsGroupedByType }) => {
+  const categories = Object.keys(resourceIdsGroupedByType)
+  const scrubbedCategories = categories.filter((category) => category !== 'Patient' && category !== 'Observation');
+  const [selectedCategory, setSelectedCategory] = useState(scrubbedCategories[0]);
 
-  return(
+  return (
     <SafeAreaView style={styles.safeAreaView}>
       <StatusBar backgroundColor={Colors.primary} barStyle="dark-content" />
       <FilterDrawer>
         <ScrollView>
           <TimelineWidget />
-          <CategorySelector 
-            categories={Object.keys(resourceIdsGroupedByType)}
-            selectedCategory={selectedCategory} 
-            setSelectedCategory={setSelectedCategory} 
+          <CategorySelector
+            categories={scrubbedCategories}
+            selectedCategory={selectedCategory}
+            setSelectedCategory={setSelectedCategory}
           />
           { selectedCategory && (
-            <RecordCardsContainer 
-              selectedCategory={selectedCategory} 
+            <RecordCardsContainer
+              selectedCategory={selectedCategory}
             />
           )}
         </ScrollView>
       </FilterDrawer>
     </SafeAreaView>
-  )
-}
+  );
+};
 
 const mapStateToProps = (state) => ({
-  resourceIdsGroupedByType: state.resourceIdsGroupedByType
-})
+  resourceIdsGroupedByType: state.resourceIdsGroupedByType,
+});
 
 export default connect(mapStateToProps, null)(CatalogScreen);
 

--- a/src/screens/CatalogScreen.js
+++ b/src/screens/CatalogScreen.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   StyleSheet, SafeAreaView, StatusBar, ScrollView,
 } from 'react-native';
+import {connect} from 'react-redux'
 
 import TimelineWidget from '../components/Timeline/TimelineWidget';
 import CategorySelector from '../components/CategorySelector/CategorySelector';
@@ -9,20 +10,34 @@ import RecordCardsContainer from '../components/RecordCard/RecordCardsContainer'
 import Colors from '../constants/Colors';
 import FilterDrawer from '../components/FilterDrawer/FilterDrawer';
 
-const CatalogScreen = () => (
-  <SafeAreaView style={styles.safeAreaView}>
-    <StatusBar backgroundColor={Colors.primary} barStyle="dark-content" />
-    <FilterDrawer>
-      <ScrollView style={styles.content}>
-        <TimelineWidget />
-        <CategorySelector />
-        <RecordCardsContainer />
-      </ScrollView>
-    </FilterDrawer>
-  </SafeAreaView>
-);
+const CatalogScreen = ({resourceIdsGroupedByType}) => {
+  const [selectedCategory, setSelectedCategory] = useState(null)
 
-export default CatalogScreen;
+  return(
+    <SafeAreaView style={styles.safeAreaView}>
+      <StatusBar backgroundColor={Colors.primary} barStyle="dark-content" />
+      <FilterDrawer>
+        <ScrollView>
+          <TimelineWidget />
+          <CategorySelector 
+            categories={Object.keys(resourceIdsGroupedByType)}
+            selectedCategory={selectedCategory} 
+            setSelectedCategory={setSelectedCategory} 
+          />
+          <RecordCardsContainer 
+            selectedCategory={selectedCategory} 
+          />
+        </ScrollView>
+      </FilterDrawer>
+    </SafeAreaView>
+  )
+}
+
+const mapStateToProps = (state) => ({
+  resourceIdsGroupedByType: state.resourceIdsGroupedByType
+})
+
+export default connect(mapStateToProps, null)(CatalogScreen);
 
 const styles = StyleSheet.create({
   safeAreaView: {
@@ -32,8 +47,5 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  content: {
-    width: '90%',
   },
 });

--- a/src/screens/CatalogScreen.js
+++ b/src/screens/CatalogScreen.js
@@ -6,12 +6,12 @@ import { connect } from 'react-redux';
 
 import TimelineWidget from '../components/Timeline/TimelineWidget';
 import CategorySelector from '../components/CategorySelector/CategorySelector';
-import RecordCardsContainer from '../components/RecordCard/RecordCardsContainer';
+import RecordCardsContainer from '../components/SubTypeAccordion/SubTypeAccordionsContainer';
 import Colors from '../constants/Colors';
 import FilterDrawer from '../components/FilterDrawer/FilterDrawer';
 
 const CatalogScreen = ({ resourceIdsGroupedByType }) => {
-  const categories = Object.keys(resourceIdsGroupedByType)
+  const categories = Object.keys(resourceIdsGroupedByType);
   const scrubbedCategories = categories.filter((category) => category !== 'Patient' && category !== 'Observation');
   const [selectedCategory, setSelectedCategory] = useState(scrubbedCategories[0]);
 

--- a/src/screens/CatalogScreen.js
+++ b/src/screens/CatalogScreen.js
@@ -4,6 +4,7 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 
+import { shape } from 'prop-types';
 import TimelineWidget from '../components/Timeline/TimelineWidget';
 import CategorySelector from '../components/CategorySelector/CategorySelector';
 import RecordCardsContainer from '../components/SubTypeAccordion/SubTypeAccordionsContainer';
@@ -35,6 +36,10 @@ const CatalogScreen = ({ resourceIdsGroupedByType }) => {
       </FilterDrawer>
     </SafeAreaView>
   );
+};
+
+CatalogScreen.propTypes = {
+  resourceIdsGroupedByType: shape({}).isRequired,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
- modify data to inject `subType` as top-level key
- parse `resourceIdsGroupedByType` state to included `subType`. Now: `category > subType > set(resourceIds)`
- build `SubTypeAccordion` via `native-base`
- connect `CategorySelector` to display the correct `SubTypeAccordion`s

![image](https://user-images.githubusercontent.com/45667486/109315813-f16e0680-7818-11eb-853b-47bbb686d311.png)
