### PR TITLE
Suppress VirtualizedList Warnings

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-
 import store from './src/redux';
 import RootNavigator from './src/navigation/RootNavigator';
+import { LogBox } from 'react-native';
+
+LogBox.ignoreLogs(['VirtualizedLists'])
 
 export default function App() {
   return (

--- a/App.js
+++ b/App.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { LogBox } from 'react-native';
 import store from './src/redux';
 import RootNavigator from './src/navigation/RootNavigator';
-import { LogBox } from 'react-native';
 
-LogBox.ignoreLogs(['VirtualizedLists'])
+LogBox.ignoreLogs(['VirtualizedLists']);
 
 export default function App() {
   return (


### PR DESCRIPTION
Can ignore specific warning types by adding a portion of their string to `LogBox.ignoreLogs(['{warning_string'])`