### PR TITLE
Update Filter Drawer

### DIFF
--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -16,27 +16,26 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/epics';
-import { orderedResourceTypeFiltersSelector } from '../../redux/selectors'
+import { orderedResourceTypeFiltersSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
-  const handleThumbColor = filterOpen
-    ? Platform.OS=='ios' 
-      ? 'white' 
-      : Colors.primary 
-    : Platform.OS=='ios' 
-      ? 'white' 
-      : Colors.lightgrey
-      
+  let thumbColor;
+  if (filterOpen) {
+    thumbColor = Platform.OS === 'ios' ? 'white' : Colors.primary;
+  } else {
+    thumbColor = Platform.OS === 'ios' ? 'white' : Colors.lightgrey;
+  }
+
   return (
     <View style={styles.categoryRow}>
       <Text>{label}</Text>
       <Switch
-        trackColor={{ 
-          false: Colors.mediumgrey, 
-          true: Platform.OS=='ios' ? Colors.primary : Colors.primaryLight 
+        trackColor={{
+          false: Colors.mediumgrey,
+          true: Platform.OS === 'ios' ? Colors.primary : Colors.primaryLight,
         }}
-        thumbColor={handleThumbColor}
+        thumbColor={thumbColor}
         onValueChange={() => toggleResourceTypeFilterAction(resourceType)}
         value={filterOpen}
       />
@@ -50,10 +49,10 @@ ResourceTypeFilter.propTypes = {
   toggleResourceTypeFilterAction: func.isRequired,
 };
 
-const FilterDrawer = ({ 
-  toggleResourceTypeFilterAction, 
-  orderedResourceTypeFilters, 
-  children 
+const FilterDrawer = ({
+  toggleResourceTypeFilterAction,
+  orderedResourceTypeFilters,
+  children,
 }) => {
   const renderDrawer = () => (
     <View style={styles.drawerContainer}>

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -7,6 +7,7 @@ import {
   Text,
   View,
   Switch,
+  Platform,
 } from 'react-native';
 import { DrawerLayout } from 'react-native-gesture-handler';
 import { widthPercentageToDP as wp } from 'react-native-responsive-screen';
@@ -15,14 +16,27 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/epics';
+import { orderedResourceTypeFiltersSelector } from '../../redux/selectors'
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
+  const handleThumbColor = filterOpen
+    ? Platform.OS=='ios' 
+      ? 'white' 
+      : Colors.primary 
+    : Platform.OS=='ios' 
+      ? 'white' 
+      : Colors.lightgrey
+      
   return (
     <View style={styles.categoryRow}>
       <Text>{label}</Text>
       <Switch
-        trackColor={{ false: Colors.mediumgrey, true: Colors.primary }}
+        trackColor={{ 
+          false: Colors.mediumgrey, 
+          true: Platform.OS=='ios' ? Colors.primary : Colors.primaryLight 
+        }}
+        thumbColor={handleThumbColor}
         onValueChange={() => toggleResourceTypeFilterAction(resourceType)}
         value={filterOpen}
       />
@@ -36,11 +50,15 @@ ResourceTypeFilter.propTypes = {
   toggleResourceTypeFilterAction: func.isRequired,
 };
 
-const FilterDrawer = ({ resourceTypeFilters, toggleResourceTypeFilterAction, children }) => {
+const FilterDrawer = ({ 
+  toggleResourceTypeFilterAction, 
+  orderedResourceTypeFilters, 
+  children 
+}) => {
   const renderDrawer = () => (
     <View style={styles.drawerContainer}>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(resourceTypeFilters).map(([resourceType, value]) => (
+      {Object.entries(orderedResourceTypeFilters).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -70,13 +88,13 @@ const FilterDrawer = ({ resourceTypeFilters, toggleResourceTypeFilterAction, chi
 };
 
 FilterDrawer.propTypes = {
-  resourceTypeFilters: shape({}).isRequired,
+  orderedResourceTypeFilters: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFilters: state.resourceTypeFilters,
+  orderedResourceTypeFilters: orderedResourceTypeFiltersSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -209,3 +209,12 @@ export const patientAgeAtResourcesSelector = createSelector(
     });
   },
 );
+
+export const orderedResourceTypeFiltersSelector = createSelector(
+  [resourceTypeFiltersSelector],
+  (resourceTypeFilters) => Object.keys(resourceTypeFilters).sort()
+    .reduce((acc, resourceType) => {
+      acc[resourceType] = resourceTypeFilters[resourceType]
+      return acc
+    }, {})
+)

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -214,7 +214,7 @@ export const orderedResourceTypeFiltersSelector = createSelector(
   [resourceTypeFiltersSelector],
   (resourceTypeFilters) => Object.keys(resourceTypeFilters).sort()
     .reduce((acc, resourceType) => {
-      acc[resourceType] = resourceTypeFilters[resourceType]
-      return acc
-    }, {})
-)
+      acc[resourceType] = resourceTypeFilters[resourceType];
+      return acc;
+    }, {}),
+);


### PR DESCRIPTION
-Update `FilterDrawer` `Switch` colors for android
-Fix andriod bug where `resourceType` order changes when toggling switches

Old
![Old Switch](https://user-images.githubusercontent.com/45667486/110255793-88e30000-7f63-11eb-89d4-12e500aa4622.gif)

New
![New Switch](https://user-images.githubusercontent.com/45667486/110255800-8d0f1d80-7f63-11eb-9b24-18d5ebe55890.gif)
