### PR TITLE
Add CountIcons to SubTypeAccordion and ResourceCard

### DIFF
--- a/src/components/Icons/CountIcon.js
+++ b/src/components/Icons/CountIcon.js
@@ -1,0 +1,88 @@
+import { bool, func, number, shape, string } from 'prop-types'
+import React from 'react'
+import { StyleSheet, TouchableOpacity } from 'react-native'
+
+import BaseText from '../Generic/BaseText'
+
+const CountIcon = ({
+  style,
+  shape, 
+  color, 
+  count, 
+  action1, 
+  action2, 
+  actionDep,
+  marginRight,
+  marginLeft,
+}) => {
+
+  const iconStyle = count > 0 ? {backgroundColor: color} : {borderWidth: 2, borderColor: color}
+  const iconCount = count > 0 ? count : null
+  const iconAction = actionDep ? action2 : action1
+  const iconMarginRight = marginRight ? styles.marginRight : {}
+  const iconMarginLeft = marginLeft ? styles.marginLeft : {}
+
+  return (
+    <TouchableOpacity 
+      style={{
+        ...styles.base,
+        ...iconMarginRight, 
+        ...iconMarginLeft,
+        ...styles[shape], 
+        ...iconStyle,
+        ...style
+      }}
+      onPress={iconAction}
+    >
+      <BaseText style={styles.text}>{iconCount}</BaseText>
+    </TouchableOpacity>
+  )
+}
+
+CountIcon.propTypes = {
+  style: shape({}),
+  shape: string.isRequired,
+  color: string.isRequired,
+  count: number,
+  action1: func,
+  action2: func,
+  actionDep: bool,
+  marginRight: bool,
+  marginLeft: bool,
+}
+
+CountIcon.defaultProps = {
+  style: {},
+  count: null,
+  action1: () => {},
+  action2: () => {},
+  actionDep: null,
+  marginRight: false,
+  marginLeft: false,
+}
+
+export default CountIcon
+
+const styles = StyleSheet.create({
+  text: {
+    color: 'white',
+  },
+  base: {
+    height: 30,
+    width: 30,
+    justifyContent: 'center',
+    alignItems: 'center', 
+  },
+  square: {
+    borderRadius: 5,
+  },
+  circle: {
+    borderRadius: 30,
+  },
+  marginRight: {
+    marginRight: 10,
+  },
+  marginLeft: {
+    marginLeft: 10,
+  }
+})

--- a/src/components/Icons/CountIcon.js
+++ b/src/components/Icons/CountIcon.js
@@ -19,8 +19,8 @@ const CountIcon = ({
   textColor,
   readOnly,
 }) => {
-  const iconStyle = count > 0 ? { backgroundColor: color } : { borderWidth: 2, borderColor: color };
   const iconCount = count > 0 ? count : null;
+  const iconStyle = actionDep ? { backgroundColor: color } : { borderWidth: 2, borderColor: color };
   const iconAction = actionDep ? action2 : action1;
   const iconMarginRight = marginRight ? styles.marginRight : {};
   const iconMarginLeft = marginLeft ? styles.marginLeft : {};
@@ -34,7 +34,7 @@ const CountIcon = ({
           ...iconMarginRight,
           ...iconMarginLeft,
           ...styles[iconShape],
-          ...iconStyle,
+          backgroundColor: color,
           ...style,
         }}
         onPress={iconAction}

--- a/src/components/Icons/CountIcon.js
+++ b/src/components/Icons/CountIcon.js
@@ -1,6 +1,6 @@
 import { bool, func, number, shape, string } from 'prop-types'
 import React from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { StyleSheet, TouchableOpacity, View } from 'react-native'
 
 import BaseText from '../Generic/BaseText'
 
@@ -14,6 +14,8 @@ const CountIcon = ({
   actionDep,
   marginRight,
   marginLeft,
+  textColor,
+  readOnly,
 }) => {
 
   const iconStyle = count > 0 ? {backgroundColor: color} : {borderWidth: 2, borderColor: color}
@@ -21,6 +23,25 @@ const CountIcon = ({
   const iconAction = actionDep ? action2 : action1
   const iconMarginRight = marginRight ? styles.marginRight : {}
   const iconMarginLeft = marginLeft ? styles.marginLeft : {}
+  const textColorStyle = textColor ? {color: textColor} : {}
+
+  if (readOnly) {
+    return (
+      <View 
+        style={{
+          ...styles.base,
+          ...iconMarginRight, 
+          ...iconMarginLeft,
+          ...styles[shape], 
+          ...iconStyle,
+          ...style
+        }}
+        onPress={iconAction}
+      >
+        <BaseText style={{...styles.text, ...textColorStyle}}>{iconCount}</BaseText>
+      </View>
+    )
+  }
 
   return (
     <TouchableOpacity 
@@ -34,7 +55,7 @@ const CountIcon = ({
       }}
       onPress={iconAction}
     >
-      <BaseText style={styles.text}>{iconCount}</BaseText>
+      <BaseText style={{...styles.text, ...textColorStyle}}>{iconCount}</BaseText>
     </TouchableOpacity>
   )
 }
@@ -49,6 +70,8 @@ CountIcon.propTypes = {
   actionDep: bool,
   marginRight: bool,
   marginLeft: bool,
+  textColorStyle: string,
+  readOnly: bool,
 }
 
 CountIcon.defaultProps = {
@@ -59,6 +82,8 @@ CountIcon.defaultProps = {
   actionDep: null,
   marginRight: false,
   marginLeft: false,
+  textColorStyle: null,
+  readOnly: false,
 }
 
 export default CountIcon

--- a/src/components/Icons/CountIcon.js
+++ b/src/components/Icons/CountIcon.js
@@ -1,64 +1,65 @@
-import { bool, func, number, shape, string } from 'prop-types'
-import React from 'react'
-import { StyleSheet, TouchableOpacity, View } from 'react-native'
+import {
+  bool, func, number, shape, string,
+} from 'prop-types';
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
-import BaseText from '../Generic/BaseText'
+import BaseText from '../Generic/BaseText';
 
 const CountIcon = ({
   style,
-  shape, 
-  color, 
-  count, 
-  action1, 
-  action2, 
+  shape: iconShape,
+  color,
+  count,
+  action1,
+  action2,
   actionDep,
   marginRight,
   marginLeft,
   textColor,
   readOnly,
 }) => {
-
-  const iconStyle = count > 0 ? {backgroundColor: color} : {borderWidth: 2, borderColor: color}
-  const iconCount = count > 0 ? count : null
-  const iconAction = actionDep ? action2 : action1
-  const iconMarginRight = marginRight ? styles.marginRight : {}
-  const iconMarginLeft = marginLeft ? styles.marginLeft : {}
-  const textColorStyle = textColor ? {color: textColor} : {}
+  const iconStyle = count > 0 ? { backgroundColor: color } : { borderWidth: 2, borderColor: color };
+  const iconCount = count > 0 ? count : null;
+  const iconAction = actionDep ? action2 : action1;
+  const iconMarginRight = marginRight ? styles.marginRight : {};
+  const iconMarginLeft = marginLeft ? styles.marginLeft : {};
+  const textColorStyle = textColor ? { color: textColor } : {};
 
   if (readOnly) {
     return (
-      <View 
+      <View
         style={{
           ...styles.base,
-          ...iconMarginRight, 
+          ...iconMarginRight,
           ...iconMarginLeft,
-          ...styles[shape], 
+          ...styles[iconShape],
           ...iconStyle,
-          ...style
+          ...style,
         }}
         onPress={iconAction}
       >
-        <BaseText style={{...styles.text, ...textColorStyle}}>{iconCount}</BaseText>
+        <BaseText style={{ ...styles.text, ...textColorStyle }}>{iconCount}</BaseText>
       </View>
-    )
+    );
   }
 
   return (
-    <TouchableOpacity 
+    <TouchableOpacity
       style={{
         ...styles.base,
-        ...iconMarginRight, 
+        ...iconMarginRight,
         ...iconMarginLeft,
-        ...styles[shape], 
+        ...styles[iconShape],
         ...iconStyle,
-        ...style
+        ...style,
       }}
       onPress={iconAction}
     >
-      <BaseText style={{...styles.text, ...textColorStyle}}>{iconCount}</BaseText>
+      <BaseText style={{ ...styles.text, ...textColorStyle }}>{iconCount}</BaseText>
     </TouchableOpacity>
-  )
-}
+  );
+};
 
 CountIcon.propTypes = {
   style: shape({}),
@@ -70,9 +71,9 @@ CountIcon.propTypes = {
   actionDep: bool,
   marginRight: bool,
   marginLeft: bool,
-  textColorStyle: string,
+  textColor: string,
   readOnly: bool,
-}
+};
 
 CountIcon.defaultProps = {
   style: {},
@@ -82,11 +83,11 @@ CountIcon.defaultProps = {
   actionDep: null,
   marginRight: false,
   marginLeft: false,
-  textColorStyle: null,
+  textColor: null,
   readOnly: false,
-}
+};
 
-export default CountIcon
+export default CountIcon;
 
 const styles = StyleSheet.create({
   text: {
@@ -96,7 +97,7 @@ const styles = StyleSheet.create({
     height: 30,
     width: 30,
     justifyContent: 'center',
-    alignItems: 'center', 
+    alignItems: 'center',
   },
   square: {
     borderRadius: 5,
@@ -109,5 +110,5 @@ const styles = StyleSheet.create({
   },
   marginLeft: {
     marginLeft: 10,
-  }
-})
+  },
+});

--- a/src/components/ResourceCard/ResourceCard.js
+++ b/src/components/ResourceCard/ResourceCard.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import {
-  StyleSheet, View, TouchableOpacity,
+  StyleSheet, View,
 } from 'react-native';
 import { string, shape, func } from 'prop-types';
 import { Button } from 'native-base';
 import { connect } from 'react-redux';
-import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 
 import GenericCardBody from './ResourceCardBody/GenericCardBody';
 import MedicationCardBody from './ResourceCardBody/MedicationCardBody';
@@ -25,6 +24,7 @@ import {
 } from '../../redux/selectors';
 import { getResourceDate } from '../../resources/fhirReader';
 import Colors from '../../constants/Colors';
+import CountIcon from '../Icons/CountIcon'
 
 const selectCardBody = (resource, patientAgeAtResource) => {
   switch (resource.type) {
@@ -75,7 +75,6 @@ const ResourceCard = ({
   selectedCollectionId,
   addResourceToCollection,
   removeResourceFromCollection,
-  lastAddedResourceId,
   collectionResourceIds,
 }) => {
   const resource = resources[resourceId];
@@ -87,12 +86,7 @@ const ResourceCard = ({
       <BaseText style={{ textAlign: 'center' }} variant="button">Add To Details Panel</BaseText>
     </Button>
   );
-  let selectedIconName = 'square-outline';
-  let selectedIconColor = Colors.lightgrey;
-  let handleOnPress = () => addResourceToCollection(selectedCollectionId, resourceId);
   if (collectionResourceIds[resourceId]) {
-    handleOnPress = () => removeResourceFromCollection(selectedCollectionId, resourceId);
-    selectedIconColor = Colors.lastSelected;
     displayButton = (
       <Button
         transparent
@@ -101,11 +95,6 @@ const ResourceCard = ({
         <BaseText style={styles.removeButton} variant="button">Remove From Details Panel</BaseText>
       </Button>
     );
-    selectedIconName = 'checkbox-outline';
-    if (lastAddedResourceId === resourceId) {
-      selectedIconName = 'checkbox';
-      selectedIconColor = Colors.lastSelected;
-    }
   }
 
   return (
@@ -114,9 +103,22 @@ const ResourceCard = ({
         <BaseText variant="header">{resourceType}</BaseText>
         <View style={styles.dateIconContainer}>
           <BaseText>{resourceDate}</BaseText>
-          <TouchableOpacity style={styles.iconContainer} onPress={handleOnPress}>
-            <Ionicons name={selectedIconName} size={24} color={selectedIconColor} />
-          </TouchableOpacity>
+          <CountIcon
+            shape="circle"
+            color={Colors.primary}
+            action1={() => {}}
+            action2={() => {}}
+            actionDep={false}
+            marginRight
+            marginLeft
+          />
+          <CountIcon
+            shape="square"
+            color={Colors.lastSelected}
+            action1={() => addResourceToCollection(selectedCollectionId, resourceId)}
+            action2={() => removeResourceFromCollection(selectedCollectionId, resourceId)}
+            actionDep={collectionResourceIds[resourceId]}
+          />
         </View>
       </View>
       <View style={styles.body}>

--- a/src/components/ResourceCard/ResourceCard.js
+++ b/src/components/ResourceCard/ResourceCard.js
@@ -19,12 +19,11 @@ import { SINGULAR_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import {
   patientSelector,
   patientAgeAtResourcesSelector,
-  lastAddedResourceIdSelector,
   collectionResourceIdsSelector,
 } from '../../redux/selectors';
 import { getResourceDate } from '../../resources/fhirReader';
 import Colors from '../../constants/Colors';
-import CountIcon from '../Icons/CountIcon'
+import CountIcon from '../Icons/CountIcon';
 
 const selectCardBody = (resource, patientAgeAtResource) => {
   switch (resource.type) {
@@ -139,12 +138,10 @@ ResourceCard.propTypes = {
   selectedCollectionId: string.isRequired,
   addResourceToCollection: func.isRequired,
   removeResourceFromCollection: func.isRequired,
-  lastAddedResourceId: string,
   collectionResourceIds: shape({}),
 };
 
 ResourceCard.defaultProps = {
-  lastAddedResourceId: null,
   collectionResourceIds: {},
 };
 
@@ -152,7 +149,6 @@ const mapStateToProps = (state) => ({
   resources: state.resources,
   patientResource: patientSelector(state),
   patientAgeAtResources: patientAgeAtResourcesSelector(state),
-  lastAddedResourceId: lastAddedResourceIdSelector(state),
   collectionResourceIds: collectionResourceIdsSelector(state),
 });
 

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -25,15 +25,20 @@ const SubTypeAccordion = ({
   subType,
 }) => {
   const dataArray = [{ title: subType, content: resourceIds }];
-  const renderHeader = (item, expanded) => {
+  const renderHeader = (item) => {
     return (
       <View style={styles.header}>
         <View style={styles.headerTextContainer}>
-          { expanded
-            ? <Ionicons name="caret-down" size={20} color={Colors.darkgrey} />
-            : <Ionicons name="caret-up" size={20} color={Colors.darkgrey} />}
+          <CountIcon 
+            shape="square" 
+            color={Colors.lightgrey}
+            count={dateFilteredCount}
+            marginRight
+            textColor="black"
+            readOnly
+          />
           <BaseText style={styles.headerText}>
-            {`${item.title} [${item.content.length}]`}
+            {item.title}
           </BaseText>
         </View>
         <View style={{flexDirection: 'row'}}>

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -126,7 +126,7 @@ const styles = StyleSheet.create({
     width: '70%',
   },
   headerText: {
-    marginLeft: 10,
+    marginLeft: 5,
     color: 'black',
   },
 });

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import {
-  StyleSheet, Text, TouchableOpacity, View,
+  StyleSheet, View,
 } from 'react-native';
 import { Accordion } from 'native-base';
-import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
 import {
@@ -12,8 +11,8 @@ import {
 import Colors from '../../constants/Colors';
 import ResourceCard from '../ResourceCard/ResourceCard';
 import { addResourceToCollection, removeResourceFromCollection } from '../../redux/epics';
-import BaseText from '../Generic/BaseText'
-import CountIcon from '../Icons/CountIcon'
+import BaseText from '../Generic/BaseText';
+import CountIcon from '../Icons/CountIcon';
 
 const SubTypeAccordion = ({
   addResourceToCollectionAction,
@@ -25,44 +24,42 @@ const SubTypeAccordion = ({
   subType,
 }) => {
   const dataArray = [{ title: subType, content: resourceIds }];
-  const renderHeader = (item) => {
-    return (
-      <View style={styles.header}>
-        <View style={styles.headerTextContainer}>
-          <CountIcon 
-            shape="square" 
-            color={Colors.lightgrey}
-            count={dateFilteredCount}
-            marginRight
-            textColor="black"
-            readOnly
-          />
-          <BaseText style={styles.headerText}>
-            {item.title}
-          </BaseText>
-        </View>
-        <View style={{flexDirection: 'row'}}>
-          <CountIcon 
-            shape="circle" 
-            color={Colors.primary}
-            count={0}
-            action1={() => {}}
-            action2={() => {}}
-            actionDep={false}
-            marginRight
-          />
-          <CountIcon 
-            shape="square" 
-            color={Colors.lastSelected}
-            count={collectionDateFilteredCount}
-            action1={() => addResourceToCollectionAction(selectedCollectionId, item.content)}
-            action2={() => removeResourceFromCollectionAction(selectedCollectionId, item.content)}
-            actionDep={collectionDateFilteredCount > 0}
-          />
-        </View>
+  const renderHeader = (item) => (
+    <View style={styles.header}>
+      <View style={styles.headerTextContainer}>
+        <CountIcon
+          shape="square"
+          color={Colors.lightgrey}
+          count={dateFilteredCount}
+          marginRight
+          textColor="black"
+          readOnly
+        />
+        <BaseText style={styles.headerText}>
+          {item.title}
+        </BaseText>
       </View>
-    );
-  };
+      <View style={{ flexDirection: 'row' }}>
+        <CountIcon
+          shape="circle"
+          color={Colors.primary}
+          count={0}
+          action1={() => {}}
+          action2={() => {}}
+          actionDep={false}
+          marginRight
+        />
+        <CountIcon
+          shape="square"
+          color={Colors.lastSelected}
+          count={collectionDateFilteredCount}
+          action1={() => addResourceToCollectionAction(selectedCollectionId, item.content)}
+          action2={() => removeResourceFromCollectionAction(selectedCollectionId, item.content)}
+          actionDep={collectionDateFilteredCount > 0}
+        />
+      </View>
+    </View>
+  );
 
   const renderContent = (item) => item.content.map(
     (resourceId) => (

--- a/src/components/SubTypeAccordion/SubTypeAccordion.js
+++ b/src/components/SubTypeAccordion/SubTypeAccordion.js
@@ -12,6 +12,8 @@ import {
 import Colors from '../../constants/Colors';
 import ResourceCard from '../ResourceCard/ResourceCard';
 import { addResourceToCollection, removeResourceFromCollection } from '../../redux/epics';
+import BaseText from '../Generic/BaseText'
+import CountIcon from '../Icons/CountIcon'
 
 const SubTypeAccordion = ({
   addResourceToCollectionAction,
@@ -24,44 +26,35 @@ const SubTypeAccordion = ({
 }) => {
   const dataArray = [{ title: subType, content: resourceIds }];
   const renderHeader = (item, expanded) => {
-    let subTypeHeaderIcon = (
-      <TouchableOpacity
-        onPress={() => addResourceToCollectionAction(selectedCollectionId, item.content)}
-      >
-        <Ionicons name="square-outline" size={24} color="white" />
-      </TouchableOpacity>
-    );
-
-    if (collectionDateFilteredCount > 0) {
-      subTypeHeaderIcon = (
-        <TouchableOpacity
-          onPress={() => addResourceToCollectionAction(selectedCollectionId, item.content)}
-        >
-          <Ionicons name="checkbox-outline" size={24} color="white" />
-        </TouchableOpacity>
-      );
-      if (collectionDateFilteredCount === dateFilteredCount) {
-        subTypeHeaderIcon = (
-          <TouchableOpacity
-            onPress={() => removeResourceFromCollectionAction(selectedCollectionId, item.content)}
-          >
-            <Ionicons name="checkbox" size={24} color="white" />
-          </TouchableOpacity>
-        );
-      }
-    }
-
     return (
       <View style={styles.header}>
         <View style={styles.headerTextContainer}>
           { expanded
-            ? <Ionicons name="caret-down" size={20} color="white" />
-            : <Ionicons name="caret-up" size={20} color="white" />}
-          <Text style={styles.headerText}>
+            ? <Ionicons name="caret-down" size={20} color={Colors.darkgrey} />
+            : <Ionicons name="caret-up" size={20} color={Colors.darkgrey} />}
+          <BaseText style={styles.headerText}>
             {`${item.title} [${item.content.length}]`}
-          </Text>
+          </BaseText>
         </View>
-        {subTypeHeaderIcon}
+        <View style={{flexDirection: 'row'}}>
+          <CountIcon 
+            shape="circle" 
+            color={Colors.primary}
+            count={0}
+            action1={() => {}}
+            action2={() => {}}
+            actionDep={false}
+            marginRight
+          />
+          <CountIcon 
+            shape="square" 
+            color={Colors.lastSelected}
+            count={collectionDateFilteredCount}
+            action1={() => addResourceToCollectionAction(selectedCollectionId, item.content)}
+            action2={() => removeResourceFromCollectionAction(selectedCollectionId, item.content)}
+            actionDep={collectionDateFilteredCount > 0}
+          />
+        </View>
       </View>
     );
   };
@@ -119,15 +112,19 @@ const styles = StyleSheet.create({
     padding: 10,
     justifyContent: 'space-between',
     alignItems: 'center',
-    backgroundColor: Colors.primary,
+    backgroundColor: 'white',
+    borderTopColor: Colors.lightgrey,
+    borderTopWidth: 1,
+    borderBottomColor: Colors.lightgrey,
+    borderBottomWidth: 1,
   },
   headerTextContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    width: '80%',
+    width: '70%',
   },
   headerText: {
     marginLeft: 10,
-    color: 'white',
+    color: 'black',
   },
 });

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -9,6 +9,7 @@ const blue5 = '#bcd2f5';
 const blue6 = '#4a648f';
 const yellow1 = '#e4c66a'; // desktop selected
 const yellow2 = '#d78c14'; // desktop last selected
+const yellow3 = '#eec15c'
 
 export default {
   primary: blue1,
@@ -19,8 +20,10 @@ export default {
   secondary: blue4,
   lightgrey: gray1,
   mediumgrey: gray2,
+  darkgrey: gray3,
   baseText: gray3,
   divider: gray1,
   selected: yellow1,
   lastSelected: yellow2,
+  collectionIcon: yellow3
 };

--- a/src/constants/Colors.js
+++ b/src/constants/Colors.js
@@ -9,7 +9,7 @@ const blue5 = '#bcd2f5';
 const blue6 = '#4a648f';
 const yellow1 = '#e4c66a'; // desktop selected
 const yellow2 = '#d78c14'; // desktop last selected
-const yellow3 = '#eec15c'
+const yellow3 = '#eec15c';
 
 export default {
   primary: blue1,
@@ -25,5 +25,5 @@ export default {
   divider: gray1,
   selected: yellow1,
   lastSelected: yellow2,
-  collectionIcon: yellow3
+  collectionIcon: yellow3,
 };


### PR DESCRIPTION
- Create reusable `CountIcon` component
- Add `CountIcon`s to `SubTypeAccordion` header and `ResourceCard`
- Update Accordion Header background color to new mockup
- Remove Accordion Arrow
- Remove SubType count in Header text

Note:
- "Marked" `CountIcon` needs to be hooked up with new "Marked" state and actions

![image](https://user-images.githubusercontent.com/45667486/111388465-b0357d80-8685-11eb-8357-b5933bd07e76.png)
