### PR TITLE
Adjust number of timeline intervals

### DIFF
--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -255,7 +255,7 @@ export const collectionsCountSelector = createSelector(
 // eslint-disable-next-line max-len
 const sortMarkedItemsBySubType = ([s1], [s2]) => ((s1.toLowerCase() < s2.toLowerCase()) ? -1 : 1);
 
-const MAX_INTERVAL_COUNT = 50;
+const MAX_INTERVAL_COUNT = 25;
 
 export const timelineIntervalsSelector = createSelector(
   [timelineItemsInRangeSelector, timelineRangeSelector, markedResourcesSelector, resourcesSelector, collectionResourceIdsSelector], // eslint-disable-line max-len


### PR DESCRIPTION
iPhone 8 vs iPad Pro:

![image](https://user-images.githubusercontent.com/3383704/113035949-afaae580-9161-11eb-8292-9b413ee287cb.png)

![image](https://user-images.githubusercontent.com/3383704/113036137-e84abf00-9161-11eb-9358-923696118cf5.png)



It seems a more dynamic implementation might be called for -- setting both the interval and bar width, based on available screen width?