### PR TITLE
Catalog Modal Update Date Picker via Record Filters

### DIFF
--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -86,8 +86,8 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl />
-              <MarkedSegmentControl />
+              <CollectionSegmentControl collection />
+              <MarkedSegmentControl marked />
               <TouchableOpacity style={styles.button} onPress={handleClearCollection}>
                 <BaseText variant="buttonDestructive">Clear Collection</BaseText>
               </TouchableOpacity>

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const collectionRecordsDescription = 'Only displays records saved to the collection.';
@@ -13,11 +15,14 @@ const collectionRecordsDescription = 'Only displays records saved to the collect
 const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowCollectionOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -35,14 +40,24 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
+  collectionDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowCollectionOnlyAction: toggleShowCollectionOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CollectionSegmentControl);

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -16,7 +16,7 @@ const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
-  filterTriggerDateRange
+  filterTriggerDateRange,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -40,13 +40,13 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
-  collectionDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const highlightedRecordsDescription = 'Only displays highlighted records.';
@@ -13,11 +15,15 @@ const highlightedRecordsDescription = 'Only displays highlighted records.';
 const MarkedSegmentControl = ({
   showMarkedOnly,
   toggleShowMarkedOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange,
 }) => {
+  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -35,14 +41,24 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
+  markedDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowMarkedOnlyAction: toggleShowMarkedOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarkedSegmentControl);

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -18,7 +18,6 @@ const MarkedSegmentControl = ({
   updateDateRangeFilter,
   filterTriggerDateRange,
 }) => {
-  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
@@ -41,13 +40,13 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
-  markedDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Timeline/DateRangePicker.js
+++ b/src/components/Timeline/DateRangePicker.js
@@ -9,7 +9,7 @@ import {
 } from 'date-fns';
 
 import DatePicker from './DatePicker';
-import { timelinePropsSelector, dateRangeFilterFiltersSelector } from '../../redux/selectors';
+import { timelinePropsSelector, dateRangeFiltersSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const DateRangePicker = ({ timelineProps, dateRangeFilter, updateDateRangeFilter }) => {
@@ -54,7 +54,7 @@ DateRangePicker.propTypes = {
 
 const mapStateToProps = (state) => ({
   timelineProps: timelinePropsSelector(state),
-  dateRangeFilter: dateRangeFilterFiltersSelector(state),
+  dateRangeFilter: dateRangeFiltersSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -473,22 +473,22 @@ export const accordionsContainerDataSelector = createSelector(
 
 export const filterTriggerDateRangeSelector = createSelector(
   [
-    resourcesSelector, 
-    selectedCollectionSelector, 
-    collectionsSelector, 
-    showMarkedOnlySelector, 
+    resourcesSelector,
+    selectedCollectionSelector,
+    collectionsSelector,
+    showMarkedOnlySelector,
     showCollectionOnlySelector,
-    (_, ownProps) => ownProps
+    (_, ownProps) => ownProps,
   ],
   (
-    resources, 
-    selectedCollectionId, 
-    collections, 
-    showMarkedOnly, 
+    resources,
+    selectedCollectionId,
+    collections,
+    showMarkedOnly,
     showCollectionOnly,
-    ownProps
+    ownProps,
   ) => {
-    const { collection, marked } = ownProps
+    const { collection, marked } = ownProps;
     const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
 
     const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
@@ -497,11 +497,11 @@ export const filterTriggerDateRangeSelector = createSelector(
     );
 
     if (collection && (collectionResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     if (marked && (markedResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
@@ -510,7 +510,7 @@ export const filterTriggerDateRangeSelector = createSelector(
       }
       return acc;
     }, []);
-    
+
     const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
       if (markedResourceIds.includes(id)) {
         acc.push(resourceValues);
@@ -525,36 +525,44 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (resources) => ({
-      dateRangeStart: startOfDay(resources[0].timelineDate),
+    const createDateRange = (res) => ({
+      dateRangeStart: startOfDay(res[0].timelineDate),
       dateRangeEnd: endOfDay(
-        resources[resources.length - 1].timelineDate,
+        res[res.length - 1].timelineDate,
       ),
-    })
+    });
 
     // feed to CollectionSegmentControl
     if (collection) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after collection setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after collection setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (!showCollectionOnly && showMarkedOnly) { // after collection setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (showCollectionOnly && showMarkedOnly) { // after collection setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
       }
     }
 
     // feed to MarkedSegmentControl
     if (marked) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (!showCollectionOnly && showMarkedOnly) { // after setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (showCollectionOnly && showMarkedOnly) { // after setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
       }
     }
 

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -105,7 +105,6 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
-    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -525,12 +525,20 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0]?.timelineDate),
-      dateRangeEnd: endOfDay(
-        res[res.length - 1]?.timelineDate,
-      ),
-    });
+    const createDateRange = (res) => {
+      if (res.length === 0) {
+        return ({
+          dateRangeStart: undefined,
+          dateRangeEnd: undefined,
+        });
+      }
+      return ({
+        dateRangeStart: startOfDay(res[0]?.timelineDate),
+        dateRangeEnd: endOfDay(
+          res[res.length - 1]?.timelineDate,
+        ),
+      });
+    };
 
     // feed to CollectionSegmentControl
     if (collection) {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -468,8 +468,8 @@ export const accordionsContainerDataSelector = createSelector(
         }
       });
     return subTypeData;
-  }
-)
+  },
+);
 
 export const filterTriggerDateRangeSelector = createSelector(
   [

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -468,5 +468,96 @@ export const accordionsContainerDataSelector = createSelector(
         }
       });
     return subTypeData;
+  }
+)
+
+export const filterTriggerDateRangeSelector = createSelector(
+  [
+    resourcesSelector, 
+    selectedCollectionSelector, 
+    collectionsSelector, 
+    showMarkedOnlySelector, 
+    showCollectionOnlySelector,
+    (_, ownProps) => ownProps
+  ],
+  (
+    resources, 
+    selectedCollectionId, 
+    collections, 
+    showMarkedOnly, 
+    showCollectionOnly,
+    ownProps
+  ) => {
+    const { collection, marked } = ownProps
+    const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
+
+    const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
+    const markedResourceIds = Object.keys(
+      collections[selectedCollectionId]?.markedResources?.marked,
+    );
+
+    if (collection && (collectionResourceIds.length === 0)) {
+      return defaultTimeRange
+    }
+
+    if (marked && (markedResourceIds.length === 0)) {
+      return defaultTimeRange
+    }
+
+    const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+      if (collectionResourceIds.includes(id)) {
+        acc.push(resourceValues);
+      }
+      return acc;
+    }, []);
+    
+    const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+      if (markedResourceIds.includes(id)) {
+        acc.push(resourceValues);
+      }
+      return acc;
+    }, []);
+
+    const sortedCollectionResources = collectionResources
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+    const sortedMarkedResources = markedResources
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+    const sortedCombinedResources = [...collectionResources, ...markedResources]
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+
+    const createDateRange = (resources) => ({
+      dateRangeStart: startOfDay(resources[0].timelineDate),
+      dateRangeEnd: endOfDay(
+        resources[resources.length - 1].timelineDate,
+      ),
+    })
+
+    // feed to CollectionSegmentControl
+    if (collection) {
+      if (!showCollectionOnly && !showMarkedOnly) { // after collection setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources)
+      } else if (showCollectionOnly && !showMarkedOnly) { // after collection setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange
+      } else if (!showCollectionOnly && showMarkedOnly) { // after collection setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources)
+      } else if (showCollectionOnly && showMarkedOnly) { // after collection setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources)
+      }
+    }
+
+    // feed to MarkedSegmentControl
+    if (marked) {
+      if (!showCollectionOnly && !showMarkedOnly) { // after setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources)
+      } else if (showCollectionOnly && !showMarkedOnly) { // after setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources)
+      } else if (!showCollectionOnly && showMarkedOnly) { // after setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange
+      } else if (showCollectionOnly && showMarkedOnly) { // after setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources)
+      }
+    }
+
+    return defaultTimeRange;
   },
 );

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -20,7 +20,7 @@ const resourceIdsGroupedByTypeSelector = (state) => state.resourceIdsGroupedByTy
 
 const selectedResourceTypeSelector = (state) => state.selectedResourceType;
 
-export const dateRangeFilterFiltersSelector = (state) => state.dateRangeFilter;
+export const dateRangeFiltersSelector = (state) => state.dateRangeFilter;
 
 const resourceTypeFiltersSelector = (state) => state.resourceTypeFilters;
 
@@ -105,6 +105,7 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
+    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({
@@ -116,10 +117,10 @@ export const timelinePropsSelector = createSelector(
 
 // either user-selected values (undefined, by default), or: min / max dates of resources
 const timelineRangeSelector = createSelector(
-  [dateRangeFilterFiltersSelector, timelinePropsSelector],
-  (dateRangeFilterFilters, timelineProps) => {
+  [dateRangeFiltersSelector, timelinePropsSelector],
+  (dateRangeFilters, timelineProps) => {
     const { minimumDate, maximumDate } = timelineProps;
-    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilterFilters;
+    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilters;
     return {
       dateRangeStart,
       dateRangeEnd,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -526,9 +526,9 @@ export const filterTriggerDateRangeSelector = createSelector(
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
     const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0].timelineDate),
+      dateRangeStart: startOfDay(res[0]?.timelineDate),
       dateRangeEnd: endOfDay(
-        res[res.length - 1].timelineDate,
+        res[res.length - 1]?.timelineDate,
       ),
     });
 


### PR DESCRIPTION
On top of #107 
- `dateRangerFilter` state gets updated by toggling `showCollectionOnly` and `showMarkedOnly`
- DatePickers and TimelineBrowser range get updated automatically by changing `dateRangeFilter`

Note: 
- Does not include "recalculation" of `timelineItems` for `TimelineBrowser`.