### PR TITLE
Catalog Modal Disable Filters & Actions

### DIFF
--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { resourceTypeFiltersParsedSelector } from '../../redux/selectors';
+import { filteredResourceTypesSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -54,12 +54,12 @@ ResourceTypeFilter.propTypes = {
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
   children,
-  resourceTypeFiltersParsed,
+  filteredResourceTypes,
 }) => {
   const renderDrawer = () => (
     <View style={styles.drawerContainer}>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(resourceTypeFiltersParsed).map(([resourceType, value]) => (
+      {Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -103,13 +103,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  resourceTypeFiltersParsed: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFiltersParsed: resourceTypeFiltersParsedSelector(state),
+  filteredResourceTypes: filteredResourceTypesSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -56,17 +56,20 @@ const FilterDrawer = ({
   children,
   filteredResourceTypes,
 }) => {
+  const hasResourceTypes = Object.keys(filteredResourceTypes).length > 0;
   const renderDrawer = () => (
     <View style={styles.drawerContainer}>
-      <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
-        <ResourceTypeFilter
-          key={resourceType}
-          resourceType={resourceType}
-          filterOpen={value}
-          toggleResourceTypeFilterAction={toggleResourceTypeFilterAction}
-        />
-      ))}
+      <Text style={styles.drawerTitle}>Category Filters</Text>
+      { hasResourceTypes
+        ? Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
+          <ResourceTypeFilter
+            key={resourceType}
+            resourceType={resourceType}
+            filterOpen={value}
+            toggleResourceTypeFilterAction={toggleResourceTypeFilterAction}
+          />
+        ))
+        : <Text style={styles.noFiltersText}>(No Resources to Filter)</Text>}
     </View>
   );
 
@@ -141,5 +144,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 20,
     marginVertical: 10,
+  },
+  noFiltersText: {
+    color: Colors.darkgrey,
+    fontStyle: 'italic',
+    width: '100%',
+    textAlign: 'center',
   },
 });

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { orderedResourceTypeFiltersSelector } from '../../redux/selectors';
+import { resourceTypeFiltersParsedSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -53,13 +53,13 @@ ResourceTypeFilter.propTypes = {
 
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
-  orderedResourceTypeFilters,
   children,
+  resourceTypeFiltersParsed,
 }) => {
   const renderDrawer = () => (
     <View style={styles.drawerContainer}>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(orderedResourceTypeFilters).map(([resourceType, value]) => (
+      {Object.entries(resourceTypeFiltersParsed).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -103,13 +103,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  orderedResourceTypeFilters: shape({}).isRequired,
+  resourceTypeFiltersParsed: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  orderedResourceTypeFilters: orderedResourceTypeFiltersSelector(state),
+  resourceTypeFiltersParsed: resourceTypeFiltersParsedSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Generic/BaseSegmentControl.js
+++ b/src/components/Generic/BaseSegmentControl.js
@@ -6,7 +6,7 @@ import {
 } from 'prop-types';
 
 const BaseSegmentControl = ({
-  values, selectedIndex, onChange, activeColor, enabled
+  values, selectedIndex, onChange, activeColor, enabled,
 }) => {
   const tintColor = activeColor || 'lightblue';
   return (
@@ -29,12 +29,12 @@ BaseSegmentControl.propTypes = {
   selectedIndex: number.isRequired,
   onChange: func.isRequired,
   activeColor: string,
-  enabled: bool
+  enabled: bool,
 };
 
 BaseSegmentControl.defaultProps = {
   activeColor: null,
-  enabled: true
+  enabled: true,
 };
 
 export default BaseSegmentControl;

--- a/src/components/Generic/BaseSegmentControl.js
+++ b/src/components/Generic/BaseSegmentControl.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
 import {
-  arrayOf, func, number, string,
+  arrayOf, bool, func, number, string,
 } from 'prop-types';
 
 const BaseSegmentControl = ({
-  values, selectedIndex, onChange, activeColor,
+  values, selectedIndex, onChange, activeColor, enabled
 }) => {
   const tintColor = activeColor || 'lightblue';
   return (
@@ -19,6 +19,7 @@ const BaseSegmentControl = ({
       fontStyle={styles.scFontStyle}
       activeFontStyle={styles.scActiveFontStyle}
       tintColor={tintColor}
+      enabled={enabled}
     />
   );
 };
@@ -28,10 +29,12 @@ BaseSegmentControl.propTypes = {
   selectedIndex: number.isRequired,
   onChange: func.isRequired,
   activeColor: string,
+  enabled: bool
 };
 
 BaseSegmentControl.defaultProps = {
   activeColor: null,
+  enabled: true
 };
 
 export default BaseSegmentControl;

--- a/src/components/Generic/BaseText.js
+++ b/src/components/Generic/BaseText.js
@@ -41,6 +41,10 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: Colors.destructive,
   },
+  buttonDisabled: {
+    fontSize: 18,
+    color: Colors.darkgrey,
+  },
   title: {
     fontWeight: '700',
     color: 'black',

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,7 +5,9 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { arrayOf, func, shape, string } from 'prop-types';
+import {
+  arrayOf, func, shape, string,
+} from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -11,19 +11,18 @@ import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
-import { collectionMarkedResourcesIdsSelector, collectionMarkedResourcesSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
-
+import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
   collectionMarkedResourcesIds,
-  collectionResourcesIds
+  collectionResourcesIds,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
-  const hasMarkedIds = collectionMarkedResourcesIds.length > 0
-  const hasCollectionIds = collectionResourcesIds.length > 0
+  const hasMarkedIds = collectionMarkedResourcesIds.length > 0;
+  const hasCollectionIds = collectionResourcesIds.length > 0;
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -92,32 +91,32 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl 
-                collection 
+              <CollectionSegmentControl
+                collection
                 hasCollectionIds={hasCollectionIds}
               />
-              <MarkedSegmentControl 
-                marked 
+              <MarkedSegmentControl
+                marked
                 hasMarkedIds={hasMarkedIds}
               />
-              <TouchableOpacity 
-                style={styles.button} 
-                onPress={handleClearCollection} 
+              <TouchableOpacity
+                style={styles.button}
+                onPress={handleClearCollection}
                 disabled={!hasCollectionIds}
               >
-                <BaseText 
-                  variant={hasCollectionIds ? "buttonDestructive" : "buttonDisabled"}
+                <BaseText
+                  variant={hasCollectionIds ? 'buttonDestructive' : 'buttonDisabled'}
                 >
                   Clear Collection
                 </BaseText>
               </TouchableOpacity>
-              <TouchableOpacity 
-                style={styles.button} 
+              <TouchableOpacity
+                style={styles.button}
                 onPress={handleClearMarked}
                 disabled={!hasMarkedIds}
               >
-                <BaseText 
-                  variant={hasMarkedIds ? "buttonDestructive" : "buttonDisabled"}
+                <BaseText
+                  variant={hasMarkedIds ? 'buttonDestructive' : 'buttonDisabled'}
                 >
                   Clear Highlighted Records
                 </BaseText>
@@ -153,7 +152,7 @@ const mapDispatchToProps = {
 const mapStateToProps = (state) => ({
   collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
   collectionResourcesIds: collectionResourceIdsSelectorArray(state),
-})
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);
 

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -94,11 +94,11 @@ const CatalogModal = ({
             <View style={styles.controlsContainer}>
               <CollectionSegmentControl 
                 collection 
-                hasCollectionIds
+                hasCollectionIds={hasCollectionIds}
               />
               <MarkedSegmentControl 
                 marked 
-                hasMarkedIds
+                hasMarkedIds={hasMarkedIds}
               />
               <TouchableOpacity 
                 style={styles.button} 

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -86,8 +86,8 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl />
-              <MarkedSegmentControl />
+              <CollectionSegmentControl collection />
+              <MarkedSegmentControl marked />
               <TouchableOpacity style={styles.button} onPress={handleClearCollection}>
                 <BaseText variant="buttonDestructive">Clear Collection</BaseText>
               </TouchableOpacity>

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,19 +5,25 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { func, string } from 'prop-types';
+import { arrayOf, func, string } from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
+import { collectionMarkedResourcesIdsSelector, collectionMarkedResourcesSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
+
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
+  collectionMarkedResourcesIds,
+  collectionResourcesIds
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
+  const hasMarkedIds = collectionMarkedResourcesIds.length > 0
+  const hasCollectionIds = collectionResourcesIds.length > 0
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -86,13 +92,35 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl collection />
-              <MarkedSegmentControl marked />
-              <TouchableOpacity style={styles.button} onPress={handleClearCollection}>
-                <BaseText variant="buttonDestructive">Clear Collection</BaseText>
+              <CollectionSegmentControl 
+                collection 
+                hasCollectionIds
+              />
+              <MarkedSegmentControl 
+                marked 
+                hasMarkedIds
+              />
+              <TouchableOpacity 
+                style={styles.button} 
+                onPress={handleClearCollection} 
+                disabled={!hasCollectionIds}
+              >
+                <BaseText 
+                  variant={hasCollectionIds ? "buttonDestructive" : "buttonDisabled"}
+                >
+                  Clear Collection
+                </BaseText>
               </TouchableOpacity>
-              <TouchableOpacity style={styles.button} onPress={handleClearMarked}>
-                <BaseText variant="buttonDestructive">Clear Highlighted Records</BaseText>
+              <TouchableOpacity 
+                style={styles.button} 
+                onPress={handleClearMarked}
+                disabled={!hasMarkedIds}
+              >
+                <BaseText 
+                  variant={hasMarkedIds ? "buttonDestructive" : "buttonDisabled"}
+                >
+                  Clear Highlighted Records
+                </BaseText>
               </TouchableOpacity>
             </View>
           </View>
@@ -113,6 +141,8 @@ CatalogModal.propTypes = {
   collectionId: string.isRequired,
   clearCollectionAction: func.isRequired,
   clearMarkedResourcesAction: func.isRequired,
+  collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
+  collectionResourcesIds: arrayOf(string.isRequired).isRequired,
 };
 
 const mapDispatchToProps = {
@@ -120,7 +150,12 @@ const mapDispatchToProps = {
   clearMarkedResourcesAction: clearMarkedResources,
 };
 
-export default connect(null, mapDispatchToProps)(CatalogModal);
+const mapStateToProps = (state) => ({
+  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
+  collectionResourcesIds: collectionResourceIdsSelectorArray(state),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,24 +5,24 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { arrayOf, func, string } from 'prop-types';
+import { arrayOf, func, shape, string } from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
-import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
+import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelector } from '../../redux/selectors';
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
   collectionMarkedResourcesIds,
-  collectionResourcesIds,
+  collectionResourcesIdsObjects,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
   const hasMarkedIds = collectionMarkedResourcesIds.length > 0;
-  const hasCollectionIds = collectionResourcesIds.length > 0;
+  const hasCollectionIds = Object.keys(collectionResourcesIdsObjects).length > 0;
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -141,7 +141,7 @@ CatalogModal.propTypes = {
   clearCollectionAction: func.isRequired,
   clearMarkedResourcesAction: func.isRequired,
   collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
-  collectionResourcesIds: arrayOf(string.isRequired).isRequired,
+  collectionResourcesIdsObjects: shape({}).isRequired,
 };
 
 const mapDispatchToProps = {
@@ -151,7 +151,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state) => ({
   collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
-  collectionResourcesIds: collectionResourceIdsSelectorArray(state),
+  collectionResourcesIdsObjects: collectionResourceIdsSelector(state),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import Colors from '../../constants/Colors';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import { selectResourceType } from '../../redux/action-creators';
+import { filteredResourceTypesSelector } from '../../redux/selectors'
 
 const CategoryButton = ({ resourceType, selectedResourceType, selectResourceTypeAction }) => {
   const categoryDisplay = PLURAL_RESOURCE_TYPES[resourceType];
@@ -37,12 +38,12 @@ CategoryButton.defaultProps = {
 };
 
 const ResourceTypeSelector = ({
-  resourceTypeFilters,
   selectResourceTypeAction,
   selectedResourceType,
+  filteredResourceTypes
 }) => (
   <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
-    {Object.entries(resourceTypeFilters).map(([resourceType, filterOpen]) => {
+    {Object.entries(filteredResourceTypes).map(([resourceType, filterOpen]) => {
       if (filterOpen) {
         return (
           <CategoryButton
@@ -59,7 +60,7 @@ const ResourceTypeSelector = ({
 );
 
 ResourceTypeSelector.propTypes = {
-  resourceTypeFilters: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   selectedResourceType: string,
   selectResourceTypeAction: func.isRequired,
 };
@@ -69,7 +70,7 @@ ResourceTypeSelector.defaultProps = {
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFilters: state.resourceTypeFilters,
+  filteredResourceTypes: filteredResourceTypesSelector(state),
   selectedResourceType: state.selectedResourceType,
 });
 

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import Colors from '../../constants/Colors';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import { selectResourceType } from '../../redux/action-creators';
-import { filteredResourceTypesSelector } from '../../redux/selectors'
+import { filteredResourceTypesSelector } from '../../redux/selectors';
 
 const CategoryButton = ({ resourceType, selectedResourceType, selectResourceTypeAction }) => {
   const categoryDisplay = PLURAL_RESOURCE_TYPES[resourceType];
@@ -40,7 +40,7 @@ CategoryButton.defaultProps = {
 const ResourceTypeSelector = ({
   selectResourceTypeAction,
   selectedResourceType,
-  filteredResourceTypes
+  filteredResourceTypes,
 }) => (
   <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
     {Object.entries(filteredResourceTypes).map(([resourceType, filterOpen]) => {

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  StyleSheet, Text,
+  StyleSheet, Text, View,
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Button } from 'native-base';
@@ -21,9 +21,11 @@ const CategoryButton = ({ resourceType, selectedResourceType, selectResourceType
     === resourceType ? styles.buttonSelectedText : styles.buttonText;
 
   return (
-    <Button rounded style={buttonStyle} onPress={() => selectResourceTypeAction(resourceType)}>
-      <Text style={buttonTextStyle}>{categoryDisplay}</Text>
-    </Button>
+    <View>
+      <Button rounded style={buttonStyle} onPress={() => selectResourceTypeAction(resourceType)}>
+        <Text style={buttonTextStyle}>{categoryDisplay}</Text>
+      </Button>
+    </View>
   );
 };
 
@@ -41,23 +43,40 @@ const ResourceTypeSelector = ({
   selectResourceTypeAction,
   selectedResourceType,
   filteredResourceTypes,
-}) => (
-  <ScrollView style={styles.root} horizontal showsHorizontalScrollIndicator={false}>
-    {Object.entries(filteredResourceTypes).map(([resourceType, filterOpen]) => {
-      if (filterOpen) {
-        return (
-          <CategoryButton
-            key={resourceType}
-            resourceType={resourceType}
-            selectedResourceType={selectedResourceType}
-            selectResourceTypeAction={selectResourceTypeAction}
-          />
-        );
-      }
-      return null;
-    })}
-  </ScrollView>
-);
+}) => {
+  const hasResourceTypes = Object.keys(filteredResourceTypes).length > 0;
+
+  if (!hasResourceTypes) {
+    return (
+      <View style={styles.noResourceTypesTextContainer}>
+        <Text style={styles.noResourceTypesText}>(No Resources to Filter)</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.root}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.contentContainerStyle}
+    >
+      {Object.entries(filteredResourceTypes).map(([resourceType, filterOpen]) => {
+        if (filterOpen) {
+          return (
+            <CategoryButton
+              key={resourceType}
+              resourceType={resourceType}
+              selectedResourceType={selectedResourceType}
+              selectResourceTypeAction={selectResourceTypeAction}
+            />
+          );
+        }
+        return null;
+      })}
+    </ScrollView>
+  );
+};
 
 ResourceTypeSelector.propTypes = {
   filteredResourceTypes: shape({}).isRequired,
@@ -84,9 +103,7 @@ const styles = StyleSheet.create({
   root: {
     backgroundColor: Colors.mediumgrey,
     borderColor: 'gray',
-    marginTop: 20,
     flexDirection: 'row',
-    padding: 10,
   },
   button: {
     paddingHorizontal: 10,
@@ -103,5 +120,22 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     color: 'black',
+  },
+  contentContainerStyle: {
+    flexDirection: 'row',
+    height: 65,
+    alignItems: 'center',
+  },
+  noResourceTypesTextContainer: {
+    height: 65,
+    width: '100%',
+    backgroundColor: Colors.mediumgrey,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  noResourceTypesText: {
+    color: Colors.darkgrey,
+    fontStyle: 'italic',
   },
 });

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionResourceIdObjects
+  collectionResourceIdObjects,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -26,17 +26,18 @@ const CollectionSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
 
-  const collectionResourceIds = Object.keys(collectionResourceIdObjects)
+  const collectionResourceIds = Object.keys(collectionResourceIdObjects);
 
-  const isEnabled = collectionResourceIds.length > 0
+  const isEnabled = collectionResourceIds.length > 0;
 
-  // reset SegmentControl and TimelineRange when user clears Collection Records while in Show Collection Only view
+  // reset SegmentControl and TimelineRange when user
+  // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
-      toggleShowMarkedOnlyAction(false)
+    if (showCollectionOnly && collectionResourceIds.length === 0) {
+      toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [showMarkedOnly, collectionMarkedResourcesIds])
+  }, [showCollectionOnly, collectionResourceIds]);
 
   return (
     <View style={styles.root}>
@@ -56,13 +57,13 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionResourceIds: shape({}).isRequired
+  collectionResourceIdObjects: shape({}).isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionResourceIdObjects: collectionResourceIdsSelector(state)
+  collectionResourceIdObjects: collectionResourceIdsSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { bool, func, shape } from 'prop-types';
@@ -6,7 +6,7 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { filterTriggerDateRangeSelector, collectionResourceIdsSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,6 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
+  collectionResourceIdObjects
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -25,12 +26,25 @@ const CollectionSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
 
+  const collectionResourceIds = Object.keys(collectionResourceIdObjects)
+
+  const isEnabled = collectionResourceIds.length > 0
+
+  // reset SegmentControl and TimelineRange when user clears Collection Records while in Show Collection Only view
+  useEffect(() => {
+    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
+      toggleShowMarkedOnlyAction(false)
+      updateDateRangeFilter(filterTriggerDateRange);
+    }
+  }, [showMarkedOnly, collectionMarkedResourcesIds])
+
   return (
     <View style={styles.root}>
       <BaseSegmentControl
         values={['All Records', 'Collection Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
+        enabled={isEnabled}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -42,11 +56,13 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
+  collectionResourceIds: shape({}).isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  collectionResourceIdObjects: collectionResourceIdsSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const collectionRecordsDescription = 'Only displays records saved to the collection.';
@@ -13,11 +15,14 @@ const collectionRecordsDescription = 'Only displays records saved to the collect
 const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowCollectionOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -35,14 +40,24 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
+  collectionDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowCollectionOnlyAction: toggleShowCollectionOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CollectionSegmentControl);

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -6,7 +6,7 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { filterTriggerDateRangeSelector, collectionResourceIdsSelector } from '../../redux/selectors';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionResourceIdObjects,
+  hasCollectionIds
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -26,18 +26,14 @@ const CollectionSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
 
-  const collectionResourceIds = Object.keys(collectionResourceIdObjects);
-
-  const isEnabled = collectionResourceIds.length > 0;
-
   // reset SegmentControl and TimelineRange when user
   // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showCollectionOnly && collectionResourceIds.length === 0) {
+    if (showCollectionOnly && hasCollectionIds) {
       toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [showCollectionOnly, collectionResourceIds]);
+  }, [showCollectionOnly, hasCollectionIds]);
 
   return (
     <View style={styles.root}>
@@ -45,7 +41,7 @@ const CollectionSegmentControl = ({
         values={['All Records', 'Collection Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
-        enabled={isEnabled}
+        enabled={hasCollectionIds}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -57,13 +53,12 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionResourceIdObjects: shape({}).isRequired,
+  hasCollectionIds: bool.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionResourceIdObjects: collectionResourceIdsSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  hasCollectionIds
+  hasCollectionIds,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -53,7 +53,7 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  hasCollectionIds: bool.isRequired
+  hasCollectionIds: bool.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -16,7 +16,7 @@ const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
-  filterTriggerDateRange
+  filterTriggerDateRange,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -40,13 +40,13 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
-  collectionDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: state.showCollectionOnly,
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -29,7 +29,7 @@ const CollectionSegmentControl = ({
   // reset SegmentControl and TimelineRange when user
   // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showCollectionOnly && hasCollectionIds) {
+    if (showCollectionOnly && !hasCollectionIds) {
       toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { array, bool, func, shape, string } from 'prop-types';
@@ -26,6 +26,14 @@ const MarkedSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
   const isEnabled = collectionMarkedResourcesIds.length > 0
+
+  // reset SegmentControl and TimelineRange when user clears Marked Records while in Show Marked Only view
+  useEffect(() => {
+    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
+      toggleShowMarkedOnlyAction(false)
+      updateDateRangeFilter(filterTriggerDateRange);
+    }
+  }, [segControlIndex, isEnabled])
 
   return (
     <View style={styles.root}>

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const highlightedRecordsDescription = 'Only displays highlighted records.';
@@ -13,11 +15,15 @@ const highlightedRecordsDescription = 'Only displays highlighted records.';
 const MarkedSegmentControl = ({
   showMarkedOnly,
   toggleShowMarkedOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange,
 }) => {
+  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -35,14 +41,24 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
+  markedDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowMarkedOnlyAction: toggleShowMarkedOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarkedSegmentControl);

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func, shape } from 'prop-types';
+import { array, bool, func, shape, string } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { filterTriggerDateRangeSelector, collectionMarkedResourcesIdsSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,6 +17,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
+  collectionMarkedResourcesIds,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
@@ -24,6 +25,7 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
+  const isEnabled = collectionMarkedResourcesIds.length > 0
 
   return (
     <View style={styles.root}>
@@ -31,6 +33,7 @@ const MarkedSegmentControl = ({
         values={['All Records', 'Highlighted Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
+        enabled={isEnabled}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -42,11 +45,13 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
+  collectionMarkedResourcesIds: array.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { array, bool, func, shape, string } from 'prop-types';
+import {
+  arrayOf, bool, func, shape, string,
+} from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
@@ -25,15 +27,16 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
-  const isEnabled = collectionMarkedResourcesIds.length > 0
+  const isEnabled = collectionMarkedResourcesIds.length > 0;
 
-  // reset SegmentControl and TimelineRange when user clears Marked Records while in Show Marked Only view
+  // reset SegmentControl and TimelineRange when user
+  // clears Marked Records while in Show Marked Only view
   useEffect(() => {
     if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
-      toggleShowMarkedOnlyAction(false)
+      toggleShowMarkedOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [segControlIndex, isEnabled])
+  }, [segControlIndex, isEnabled]);
 
   return (
     <View style={styles.root}>
@@ -53,13 +56,13 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionMarkedResourcesIds: array.isRequired
+  collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state)
+  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -19,7 +19,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  hasMarkedIds
+  hasMarkedIds,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -18,7 +18,6 @@ const MarkedSegmentControl = ({
   updateDateRangeFilter,
   filterTriggerDateRange,
 }) => {
-  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
@@ -41,13 +40,13 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
-  markedDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -2,13 +2,13 @@ import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import {
-  arrayOf, bool, func, shape, string,
+  bool, func, shape,
 } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { filterTriggerDateRangeSelector, collectionMarkedResourcesIdsSelector } from '../../redux/selectors';
+import { filterTriggerDateRangeSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -19,7 +19,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionMarkedResourcesIds,
+  hasMarkedIds
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
@@ -27,16 +27,15 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
-  const isEnabled = collectionMarkedResourcesIds.length > 0;
 
   // reset SegmentControl and TimelineRange when user
   // clears Marked Records while in Show Marked Only view
   useEffect(() => {
-    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
+    if (showMarkedOnly && !hasMarkedIds) {
       toggleShowMarkedOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [segControlIndex, isEnabled]);
+  }, [showMarkedOnly, hasMarkedIds]);
 
   return (
     <View style={styles.root}>
@@ -44,7 +43,7 @@ const MarkedSegmentControl = ({
         values={['All Records', 'Highlighted Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
-        enabled={isEnabled}
+        enabled={hasMarkedIds}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -56,13 +55,12 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
+  hasMarkedIds: bool.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: state.showMarkedOnly,
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Timeline/DateRangePicker.js
+++ b/src/components/Timeline/DateRangePicker.js
@@ -9,7 +9,7 @@ import {
 } from 'date-fns';
 
 import DatePicker from './DatePicker';
-import { timelinePropsSelector, dateRangeFilterFiltersSelector } from '../../redux/selectors';
+import { timelinePropsSelector, dateRangeFiltersSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const DateRangePicker = ({ timelineProps, dateRangeFilter, updateDateRangeFilter }) => {
@@ -54,7 +54,7 @@ DateRangePicker.propTypes = {
 
 const mapStateToProps = (state) => ({
   timelineProps: timelinePropsSelector(state),
-  dateRangeFilter: dateRangeFilterFiltersSelector(state),
+  dateRangeFilter: dateRangeFiltersSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -42,11 +42,6 @@ export const collectionResourceIdsSelector = createSelector(
   (collection) => collection.resourceIds,
 );
 
-export const collectionResourceIdsSelectorArray = createSelector(
-  [collectionSelector],
-  (collection) => Object.keys(collection.resourceIds),
-);
-
 export const collectionMarkedResourcesSelector = createSelector(
   [collectionSelector],
   (collection) => collection.markedResources,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -473,22 +473,22 @@ export const accordionsContainerDataSelector = createSelector(
 
 export const filterTriggerDateRangeSelector = createSelector(
   [
-    resourcesSelector, 
-    selectedCollectionSelector, 
-    collectionsSelector, 
-    showMarkedOnlySelector, 
+    resourcesSelector,
+    selectedCollectionSelector,
+    collectionsSelector,
+    showMarkedOnlySelector,
     showCollectionOnlySelector,
-    (_, ownProps) => ownProps
+    (_, ownProps) => ownProps,
   ],
   (
-    resources, 
-    selectedCollectionId, 
-    collections, 
-    showMarkedOnly, 
+    resources,
+    selectedCollectionId,
+    collections,
+    showMarkedOnly,
     showCollectionOnly,
-    ownProps
+    ownProps,
   ) => {
-    const { collection, marked } = ownProps
+    const { collection, marked } = ownProps;
     const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
 
     const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
@@ -497,11 +497,11 @@ export const filterTriggerDateRangeSelector = createSelector(
     );
 
     if (collection && (collectionResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     if (marked && (markedResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
@@ -510,7 +510,7 @@ export const filterTriggerDateRangeSelector = createSelector(
       }
       return acc;
     }, []);
-    
+
     const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
       if (markedResourceIds.includes(id)) {
         acc.push(resourceValues);
@@ -525,36 +525,44 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (resources) => ({
-      dateRangeStart: startOfDay(resources[0].timelineDate),
+    const createDateRange = (res) => ({
+      dateRangeStart: startOfDay(res[0].timelineDate),
       dateRangeEnd: endOfDay(
-        resources[resources.length - 1].timelineDate,
+        res[res.length - 1].timelineDate,
       ),
-    })
+    });
 
     // feed to CollectionSegmentControl
     if (collection) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after collection setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after collection setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (!showCollectionOnly && showMarkedOnly) { // after collection setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (showCollectionOnly && showMarkedOnly) { // after collection setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
       }
     }
 
     // feed to MarkedSegmentControl
     if (marked) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (!showCollectionOnly && showMarkedOnly) { // after setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (showCollectionOnly && showMarkedOnly) { // after setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
       }
     }
 

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -105,7 +105,6 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
-    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -525,12 +525,20 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0]?.timelineDate),
-      dateRangeEnd: endOfDay(
-        res[res.length - 1]?.timelineDate,
-      ),
-    });
+    const createDateRange = (res) => {
+      if (res.length === 0) {
+        return ({
+          dateRangeStart: undefined,
+          dateRangeEnd: undefined,
+        });
+      }
+      return ({
+        dateRangeStart: startOfDay(res[0]?.timelineDate),
+        dateRangeEnd: endOfDay(
+          res[res.length - 1]?.timelineDate,
+        ),
+      });
+    };
 
     // feed to CollectionSegmentControl
     if (collection) {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -468,8 +468,8 @@ export const accordionsContainerDataSelector = createSelector(
         }
       });
     return subTypeData;
-  }
-)
+  },
+);
 
 export const filterTriggerDateRangeSelector = createSelector(
   [

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -468,5 +468,96 @@ export const accordionsContainerDataSelector = createSelector(
         }
       });
     return subTypeData;
+  }
+)
+
+export const filterTriggerDateRangeSelector = createSelector(
+  [
+    resourcesSelector, 
+    selectedCollectionSelector, 
+    collectionsSelector, 
+    showMarkedOnlySelector, 
+    showCollectionOnlySelector,
+    (_, ownProps) => ownProps
+  ],
+  (
+    resources, 
+    selectedCollectionId, 
+    collections, 
+    showMarkedOnly, 
+    showCollectionOnly,
+    ownProps
+  ) => {
+    const { collection, marked } = ownProps
+    const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
+
+    const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
+    const markedResourceIds = Object.keys(
+      collections[selectedCollectionId]?.markedResources?.marked,
+    );
+
+    if (collection && (collectionResourceIds.length === 0)) {
+      return defaultTimeRange
+    }
+
+    if (marked && (markedResourceIds.length === 0)) {
+      return defaultTimeRange
+    }
+
+    const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+      if (collectionResourceIds.includes(id)) {
+        acc.push(resourceValues);
+      }
+      return acc;
+    }, []);
+    
+    const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+      if (markedResourceIds.includes(id)) {
+        acc.push(resourceValues);
+      }
+      return acc;
+    }, []);
+
+    const sortedCollectionResources = collectionResources
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+    const sortedMarkedResources = markedResources
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+    const sortedCombinedResources = [...collectionResources, ...markedResources]
+      .sort((a, b) => a.timelineDate - b.timelineDate);
+
+    const createDateRange = (resources) => ({
+      dateRangeStart: startOfDay(resources[0].timelineDate),
+      dateRangeEnd: endOfDay(
+        resources[resources.length - 1].timelineDate,
+      ),
+    })
+
+    // feed to CollectionSegmentControl
+    if (collection) {
+      if (!showCollectionOnly && !showMarkedOnly) { // after collection setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources)
+      } else if (showCollectionOnly && !showMarkedOnly) { // after collection setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange
+      } else if (!showCollectionOnly && showMarkedOnly) { // after collection setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources)
+      } else if (showCollectionOnly && showMarkedOnly) { // after collection setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources)
+      }
+    }
+
+    // feed to MarkedSegmentControl
+    if (marked) {
+      if (!showCollectionOnly && !showMarkedOnly) { // after setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources)
+      } else if (showCollectionOnly && !showMarkedOnly) { // after setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources)
+      } else if (!showCollectionOnly && showMarkedOnly) { // after setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange
+      } else if (showCollectionOnly && showMarkedOnly) { // after setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources)
+      }
+    }
+
+    return defaultTimeRange;
   },
 );

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -47,6 +47,11 @@ export const collectionMarkedResourcesSelector = createSelector(
   (collection) => collection.markedResources,
 );
 
+export const collectionMarkedResourcesIdsSelector = createSelector(
+  [collectionSelector],
+  (collection) => Object.keys(collection.markedResources.marked),
+);
+
 const collectionAndMarkedResourceIdsSelector = createSelector(
   [collectionResourceIdsSelector, collectionMarkedResourcesSelector],
   (collectionResourceIds, collectionMarkedResources) => {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -42,6 +42,11 @@ export const collectionResourceIdsSelector = createSelector(
   (collection) => collection.resourceIds,
 );
 
+export const collectionResourceIdsSelectorArray = createSelector(
+  [collectionSelector],
+  (collection) => Object.keys(collection.resourceIds),
+);
+
 export const collectionMarkedResourcesSelector = createSelector(
   [collectionSelector],
   (collection) => collection.markedResources,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -585,8 +585,8 @@ export const filterTriggerDateRangeSelector = createSelector(
 const filteredResourceIdsSelector = createSelector(
   [
     resourcesSelector,
-    collectionResourceIdsSelector, 
-    collectionMarkedResourcesSelector, 
+    collectionResourceIdsSelector,
+    collectionMarkedResourcesSelector,
     collectionAndMarkedResourceIdsSelector,
     showCollectionOnlySelector,
     showMarkedOnlySelector,
@@ -600,29 +600,29 @@ const filteredResourceIdsSelector = createSelector(
     showMarkedOnly,
   ) => {
     if (showCollectionOnly && !showMarkedOnly) {
-      return Object.keys(collectionResourceIds)
+      return Object.keys(collectionResourceIds);
     }
     if (!showCollectionOnly && showMarkedOnly) {
-      return Object.keys(collectionMarkedResources.marked)
+      return Object.keys(collectionMarkedResources.marked);
     }
     if (showCollectionOnly && showMarkedOnly) {
-      return collectionAndMarkedResourceIds
+      return collectionAndMarkedResourceIds;
     }
     // therefore !showMarkedOnly && !showMarkedOnly
-    return Object.keys(resources)
-  }
-)
+    return Object.keys(resources);
+  },
+);
 
 export const filteredResourceTypesSelector = createSelector(
   [
     resourcesSelector,
     resourceTypeFiltersSelector,
-    filteredResourceIdsSelector
+    filteredResourceIdsSelector,
   ],
   (
     resources,
     resourceTypeFilters,
-    filteredResourceIds
+    filteredResourceIds,
   ) => {
     const resourceTypesFromSelectedIds = [];
     filteredResourceIds.forEach((id) => {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -20,7 +20,7 @@ const resourceIdsGroupedByTypeSelector = (state) => state.resourceIdsGroupedByTy
 
 const selectedResourceTypeSelector = (state) => state.selectedResourceType;
 
-export const dateRangeFilterFiltersSelector = (state) => state.dateRangeFilter;
+export const dateRangeFiltersSelector = (state) => state.dateRangeFilter;
 
 const resourceTypeFiltersSelector = (state) => state.resourceTypeFilters;
 
@@ -105,6 +105,7 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
+    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({
@@ -116,10 +117,10 @@ export const timelinePropsSelector = createSelector(
 
 // either user-selected values (undefined, by default), or: min / max dates of resources
 const timelineRangeSelector = createSelector(
-  [dateRangeFilterFiltersSelector, timelinePropsSelector],
-  (dateRangeFilterFilters, timelineProps) => {
+  [dateRangeFiltersSelector, timelinePropsSelector],
+  (dateRangeFilters, timelineProps) => {
     const { minimumDate, maximumDate } = timelineProps;
-    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilterFilters;
+    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilters;
     return {
       dateRangeStart,
       dateRangeEnd,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -185,15 +185,6 @@ export const patientAgeAtResourcesSelector = createSelector(
   },
 );
 
-export const orderedResourceTypeFiltersSelector = createSelector(
-  [resourceTypeFiltersSelector],
-  (resourceTypeFilters) => Object.keys(resourceTypeFilters).sort()
-    .reduce((acc, resourceType) => {
-      acc[resourceType] = resourceTypeFilters[resourceType];
-      return acc;
-    }, {}),
-);
-
 export const lastAddedResourceIdSelector = createSelector(
   [collectionsSelector, selectedCollectionSelector],
   (collections, selectedCollectionId) => collections[selectedCollectionId].lastAddedResourceId,
@@ -210,7 +201,7 @@ const subTypeResourceIdsSelector = createSelector(
   }, {}),
 );
 
-const filteredResourceTypesSelector = createSelector(
+const accordionDataBuilderSelector = createSelector(
   [
     collectionResourceIdsSelector,
     collectionMarkedResourcesSelector,
@@ -404,7 +395,7 @@ export const timelineIntervalsSelector = createSelector(
 
 export const accordionsContainerDataSelector = createSelector(
   [
-    filteredResourceTypesSelector,
+    accordionDataBuilderSelector,
     selectedResourceTypeSelector,
     showCollectionOnlySelector,
     showMarkedOnlySelector,
@@ -591,49 +582,59 @@ export const filterTriggerDateRangeSelector = createSelector(
   },
 );
 
-export const resourceTypeFiltersParsedSelector = createSelector(
+const filteredResourceIdsSelector = createSelector(
   [
     resourcesSelector,
-    orderedResourceTypeFiltersSelector,
-    collectionResourceIdsSelector,
-    collectionMarkedResourcesSelector,
+    collectionResourceIdsSelector, 
+    collectionMarkedResourcesSelector, 
     collectionAndMarkedResourceIdsSelector,
     showCollectionOnlySelector,
     showMarkedOnlySelector,
   ],
   (
     resources,
-    orderedResourceTypeFilters,
     collectionResourceIds,
     collectionMarkedResources,
     collectionAndMarkedResourceIds,
     showCollectionOnly,
     showMarkedOnly,
   ) => {
-    if (!showCollectionOnly && !showMarkedOnly) {
-      return orderedResourceTypeFilters;
-    }
-
-    let selectedIds;
     if (showCollectionOnly && !showMarkedOnly) {
-      selectedIds = Object.keys(collectionResourceIds);
-    } if (!showCollectionOnly && showMarkedOnly) {
-      selectedIds = Object.keys(collectionMarkedResources.marked);
-    } if (showCollectionOnly && showMarkedOnly) {
-      selectedIds = collectionAndMarkedResourceIds;
+      return Object.keys(collectionResourceIds)
     }
+    if (!showCollectionOnly && showMarkedOnly) {
+      return Object.keys(collectionMarkedResources.marked)
+    }
+    if (showCollectionOnly && showMarkedOnly) {
+      return collectionAndMarkedResourceIds
+    }
+    // therefore !showMarkedOnly && !showMarkedOnly
+    return Object.keys(resources)
+  }
+)
 
+export const filteredResourceTypesSelector = createSelector(
+  [
+    resourcesSelector,
+    resourceTypeFiltersSelector,
+    filteredResourceIdsSelector
+  ],
+  (
+    resources,
+    resourceTypeFilters,
+    filteredResourceIds
+  ) => {
     const resourceTypesFromSelectedIds = [];
-    selectedIds.forEach((id) => {
+    filteredResourceIds.forEach((id) => {
       const { type } = resources[id];
-      if (Object.keys(orderedResourceTypeFilters).includes(type)) {
+      if (Object.keys(resourceTypeFilters).includes(type)) {
         resourceTypesFromSelectedIds.push(type);
       }
     });
 
     return resourceTypesFromSelectedIds.sort().reduce((acc, type) => {
-      if (Object.keys(orderedResourceTypeFilters).includes(type)) {
-        acc[type] = orderedResourceTypeFilters[type];
+      if (Object.keys(resourceTypeFilters).includes(type)) {
+        acc[type] = resourceTypeFilters[type];
       }
       return acc;
     }, {});

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -526,9 +526,9 @@ export const filterTriggerDateRangeSelector = createSelector(
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
     const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0].timelineDate),
+      dateRangeStart: startOfDay(res[0]?.timelineDate),
       dateRangeEnd: endOfDay(
-        res[res.length - 1].timelineDate,
+        res[res.length - 1]?.timelineDate,
       ),
     });
 


### PR DESCRIPTION
On top of #111
Disable `CatalogModal` respective UI when `collectionIds` or `markedResourcesIds` is 0.

Notes: 
- This will need to be updated when `updateDateRangeFilter` becomes obsolete

https://user-images.githubusercontent.com/45667486/114423607-55f4e300-9b85-11eb-9a1e-ce5bf428ff7c.mov

