### PR TITLE
Catalog Modal Updates

### DIFF
--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { orderedResourceTypeFiltersSelector } from '../../redux/selectors';
+import { resourceTypeFiltersParsedSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -53,13 +53,13 @@ ResourceTypeFilter.propTypes = {
 
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
-  orderedResourceTypeFilters,
   children,
+  resourceTypeFiltersParsed,
 }) => {
   const renderDrawer = () => (
     <View>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(orderedResourceTypeFilters).map(([resourceType, value]) => (
+      {Object.entries(resourceTypeFiltersParsed).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -101,13 +101,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  orderedResourceTypeFilters: shape({}).isRequired,
+  resourceTypeFiltersParsed: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  orderedResourceTypeFilters: orderedResourceTypeFiltersSelector(state),
+  resourceTypeFiltersParsed: resourceTypeFiltersParsedSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { filteredResourceTypesSelector } from '../../redux/selectors';
+import { filteredResourceTypesSelector, activeCollectionResourceTypeFiltersSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -54,12 +54,12 @@ ResourceTypeFilter.propTypes = {
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
   children,
-  filteredResourceTypes,
+  resourceTypeFilters,
 }) => {
   const renderDrawer = () => (
     <View>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
+      {Object.entries(resourceTypeFilters).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -101,13 +101,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  filteredResourceTypes: shape({}).isRequired,
+  resourceTypeFilters: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  filteredResourceTypes: filteredResourceTypesSelector(state),
+  resourceTypeFilters: activeCollectionResourceTypeFiltersSelector(state),
 });
 
 const mapDispatchToProps = {
@@ -132,5 +132,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 20,
     marginVertical: 10,
+  },
+  noFiltersText: {
+    color: Colors.darkgrey,
+    fontStyle: 'italic',
+    width: '100%',
+    textAlign: 'center',
   },
 });

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { filteredResourceTypesSelector, activeCollectionResourceTypeFiltersSelector } from '../../redux/selectors';
+import { activeCollectionResourceTypeFiltersSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { activeCollectionResourceTypeFiltersSelector } from '../../redux/selectors';
+import { filteredResourceTypesSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -54,12 +54,12 @@ ResourceTypeFilter.propTypes = {
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
   children,
-  resourceTypeFilters,
+  filteredResourceTypes,
 }) => {
   const renderDrawer = () => (
     <View>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(resourceTypeFilters).map(([resourceType, value]) => (
+      {Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -101,13 +101,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  resourceTypeFilters: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFilters: activeCollectionResourceTypeFiltersSelector(state),
+  filteredResourceTypes: filteredResourceTypesSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/FilterDrawer/FilterDrawer.js
+++ b/src/components/FilterDrawer/FilterDrawer.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import Colors from '../../constants/Colors';
 import { toggleResourceTypeFilter } from '../../redux/action-creators';
-import { resourceTypeFiltersParsedSelector } from '../../redux/selectors';
+import { filteredResourceTypesSelector } from '../../redux/selectors';
 
 const ResourceTypeFilter = ({ resourceType, filterOpen, toggleResourceTypeFilterAction }) => {
   const label = PLURAL_RESOURCE_TYPES[resourceType];
@@ -54,12 +54,12 @@ ResourceTypeFilter.propTypes = {
 const FilterDrawer = ({
   toggleResourceTypeFilterAction,
   children,
-  resourceTypeFiltersParsed,
+  filteredResourceTypes,
 }) => {
   const renderDrawer = () => (
     <View>
       <Text style={styles.drawerTitle}>Resource Type Filters</Text>
-      {Object.entries(resourceTypeFiltersParsed).map(([resourceType, value]) => (
+      {Object.entries(filteredResourceTypes).map(([resourceType, value]) => (
         <ResourceTypeFilter
           key={resourceType}
           resourceType={resourceType}
@@ -101,13 +101,13 @@ const FilterDrawer = ({
 };
 
 FilterDrawer.propTypes = {
-  resourceTypeFiltersParsed: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   toggleResourceTypeFilterAction: func.isRequired,
   children: node.isRequired,
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFiltersParsed: resourceTypeFiltersParsedSelector(state),
+  filteredResourceTypes: filteredResourceTypesSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Generic/BaseSegmentControl.js
+++ b/src/components/Generic/BaseSegmentControl.js
@@ -6,7 +6,7 @@ import {
 } from 'prop-types';
 
 const BaseSegmentControl = ({
-  values, selectedIndex, onChange, activeColor, enabled
+  values, selectedIndex, onChange, activeColor, enabled,
 }) => {
   const tintColor = activeColor || 'lightblue';
   return (
@@ -29,12 +29,12 @@ BaseSegmentControl.propTypes = {
   selectedIndex: number.isRequired,
   onChange: func.isRequired,
   activeColor: string,
-  enabled: bool
+  enabled: bool,
 };
 
 BaseSegmentControl.defaultProps = {
   activeColor: null,
-  enabled: true
+  enabled: true,
 };
 
 export default BaseSegmentControl;

--- a/src/components/Generic/BaseSegmentControl.js
+++ b/src/components/Generic/BaseSegmentControl.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
 import {
-  arrayOf, func, number, string,
+  arrayOf, bool, func, number, string,
 } from 'prop-types';
 
 const BaseSegmentControl = ({
-  values, selectedIndex, onChange, activeColor,
+  values, selectedIndex, onChange, activeColor, enabled
 }) => {
   const tintColor = activeColor || 'lightblue';
   return (
@@ -19,6 +19,7 @@ const BaseSegmentControl = ({
       fontStyle={styles.scFontStyle}
       activeFontStyle={styles.scActiveFontStyle}
       tintColor={tintColor}
+      enabled={enabled}
     />
   );
 };
@@ -28,10 +29,12 @@ BaseSegmentControl.propTypes = {
   selectedIndex: number.isRequired,
   onChange: func.isRequired,
   activeColor: string,
+  enabled: bool
 };
 
 BaseSegmentControl.defaultProps = {
   activeColor: null,
+  enabled: true
 };
 
 export default BaseSegmentControl;

--- a/src/components/Generic/BaseText.js
+++ b/src/components/Generic/BaseText.js
@@ -41,6 +41,10 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: Colors.destructive,
   },
+  buttonDisabled: {
+    fontSize: 18,
+    color: Colors.darkgrey,
+  },
   title: {
     fontWeight: '700',
     color: 'black',

--- a/src/components/Icons/CollectionIcon.js
+++ b/src/components/Icons/CollectionIcon.js
@@ -6,7 +6,7 @@ import { StyleSheet, TouchableOpacity, Text } from 'react-native';
 import { connect } from 'react-redux';
 import Colors from '../../constants/Colors';
 
-import { collectionResourceIdsSelector, activeCollectionShowCollectionOnlySelector } from '../../redux/selectors';
+import { activeCollectionResourceIdsSelector, activeCollectionShowCollectionOnlySelector } from '../../redux/selectors';
 import { addResourceToCollection, removeResourceFromCollection } from '../../redux/action-creators';
 
 const CollectionIcon = ({
@@ -60,7 +60,7 @@ CollectionIcon.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  collectionResourceIds: collectionResourceIdsSelector(state),
+  collectionResourceIds: activeCollectionResourceIdsSelector(state),
   showCollectionOnly: activeCollectionShowCollectionOnlySelector(state),
 });
 

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -4,27 +4,27 @@ import {
 } from 'react-native';
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
-
 import {
-  arrayOf, func, shape, string,
+  func, shape, string,
 } from 'prop-types';
+
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
-import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelector } from '../../redux/selectors';
+import { activeCollectionResourceIdsSelector, activeCollectionMarkedResourcesSelector } from '../../redux/selectors';
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
-  collectionMarkedResourcesIds,
-  collectionResourcesIdsObjects,
+  collectionMarkedResources,
+  collectionResources,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
-  const hasMarkedIds = collectionMarkedResourcesIds.length > 0;
-  const hasCollectionIds = Object.keys(collectionResourcesIdsObjects).length > 0;
+  const hasMarkedIds = Object.keys(collectionMarkedResources).length > 0;
+  const hasCollectionIds = Object.keys(collectionResources).length > 0;
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -142,8 +142,8 @@ CatalogModal.propTypes = {
   collectionId: string.isRequired,
   clearCollectionAction: func.isRequired,
   clearMarkedResourcesAction: func.isRequired,
-  collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
-  collectionResourcesIdsObjects: shape({}).isRequired,
+  collectionMarkedResources: shape({}).isRequired,
+  collectionResources: shape({}).isRequired,
 };
 
 const mapDispatchToProps = {
@@ -152,8 +152,8 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = (state) => ({
-  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
-  collectionResourcesIdsObjects: collectionResourceIdsSelector(state),
+  collectionMarkedResources: activeCollectionMarkedResourcesSelector(state),
+  collectionResources: activeCollectionResourceIdsSelector(state),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,7 +5,9 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { arrayOf, func, shape, string } from 'prop-types';
+import {
+  arrayOf, func, shape, string,
+} from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -23,7 +23,7 @@ const CatalogModal = ({
   collectionResources,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
-  const hasMarkedIds = Object.keys(collectionMarkedResources).length > 0;
+  const hasMarkedIds = Object.keys(collectionMarkedResources.marked).length > 0;
   const hasCollectionIds = Object.keys(collectionResources).length > 0;
 
   const handleClearCollection = () => {

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -11,19 +11,18 @@ import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
-import { collectionMarkedResourcesIdsSelector, collectionMarkedResourcesSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
-
+import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
   collectionMarkedResourcesIds,
-  collectionResourcesIds
+  collectionResourcesIds,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
-  const hasMarkedIds = collectionMarkedResourcesIds.length > 0
-  const hasCollectionIds = collectionResourcesIds.length > 0
+  const hasMarkedIds = collectionMarkedResourcesIds.length > 0;
+  const hasCollectionIds = collectionResourcesIds.length > 0;
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -92,32 +91,32 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl 
-                collection 
+              <CollectionSegmentControl
+                collection
                 hasCollectionIds={hasCollectionIds}
               />
-              <MarkedSegmentControl 
-                marked 
+              <MarkedSegmentControl
+                marked
                 hasMarkedIds={hasMarkedIds}
               />
-              <TouchableOpacity 
-                style={styles.button} 
-                onPress={handleClearCollection} 
+              <TouchableOpacity
+                style={styles.button}
+                onPress={handleClearCollection}
                 disabled={!hasCollectionIds}
               >
-                <BaseText 
-                  variant={hasCollectionIds ? "buttonDestructive" : "buttonDisabled"}
+                <BaseText
+                  variant={hasCollectionIds ? 'buttonDestructive' : 'buttonDisabled'}
                 >
                   Clear Collection
                 </BaseText>
               </TouchableOpacity>
-              <TouchableOpacity 
-                style={styles.button} 
+              <TouchableOpacity
+                style={styles.button}
                 onPress={handleClearMarked}
                 disabled={!hasMarkedIds}
               >
-                <BaseText 
-                  variant={hasMarkedIds ? "buttonDestructive" : "buttonDisabled"}
+                <BaseText
+                  variant={hasMarkedIds ? 'buttonDestructive' : 'buttonDisabled'}
                 >
                   Clear Highlighted Records
                 </BaseText>
@@ -153,7 +152,7 @@ const mapDispatchToProps = {
 const mapStateToProps = (state) => ({
   collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
   collectionResourcesIds: collectionResourceIdsSelectorArray(state),
-})
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);
 

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -94,11 +94,11 @@ const CatalogModal = ({
             <View style={styles.controlsContainer}>
               <CollectionSegmentControl 
                 collection 
-                hasCollectionIds
+                hasCollectionIds={hasCollectionIds}
               />
               <MarkedSegmentControl 
                 marked 
-                hasMarkedIds
+                hasMarkedIds={hasMarkedIds}
               />
               <TouchableOpacity 
                 style={styles.button} 

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -86,8 +86,8 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl />
-              <MarkedSegmentControl />
+              <CollectionSegmentControl collection />
+              <MarkedSegmentControl marked />
               <TouchableOpacity style={styles.button} onPress={handleClearCollection}>
                 <BaseText variant="buttonDestructive">Clear Collection</BaseText>
               </TouchableOpacity>

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,19 +5,25 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { func, string } from 'prop-types';
+import { arrayOf, func, string } from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
+import { collectionMarkedResourcesIdsSelector, collectionMarkedResourcesSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
+
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
+  collectionMarkedResourcesIds,
+  collectionResourcesIds
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
+  const hasMarkedIds = collectionMarkedResourcesIds.length > 0
+  const hasCollectionIds = collectionResourcesIds.length > 0
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -86,13 +92,35 @@ const CatalogModal = ({
               </TouchableOpacity>
             </View>
             <View style={styles.controlsContainer}>
-              <CollectionSegmentControl collection />
-              <MarkedSegmentControl marked />
-              <TouchableOpacity style={styles.button} onPress={handleClearCollection}>
-                <BaseText variant="buttonDestructive">Clear Collection</BaseText>
+              <CollectionSegmentControl 
+                collection 
+                hasCollectionIds
+              />
+              <MarkedSegmentControl 
+                marked 
+                hasMarkedIds
+              />
+              <TouchableOpacity 
+                style={styles.button} 
+                onPress={handleClearCollection} 
+                disabled={!hasCollectionIds}
+              >
+                <BaseText 
+                  variant={hasCollectionIds ? "buttonDestructive" : "buttonDisabled"}
+                >
+                  Clear Collection
+                </BaseText>
               </TouchableOpacity>
-              <TouchableOpacity style={styles.button} onPress={handleClearMarked}>
-                <BaseText variant="buttonDestructive">Clear Highlighted Records</BaseText>
+              <TouchableOpacity 
+                style={styles.button} 
+                onPress={handleClearMarked}
+                disabled={!hasMarkedIds}
+              >
+                <BaseText 
+                  variant={hasMarkedIds ? "buttonDestructive" : "buttonDisabled"}
+                >
+                  Clear Highlighted Records
+                </BaseText>
               </TouchableOpacity>
             </View>
           </View>
@@ -113,6 +141,8 @@ CatalogModal.propTypes = {
   collectionId: string.isRequired,
   clearCollectionAction: func.isRequired,
   clearMarkedResourcesAction: func.isRequired,
+  collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
+  collectionResourcesIds: arrayOf(string.isRequired).isRequired,
 };
 
 const mapDispatchToProps = {
@@ -120,7 +150,12 @@ const mapDispatchToProps = {
   clearMarkedResourcesAction: clearMarkedResources,
 };
 
-export default connect(null, mapDispatchToProps)(CatalogModal);
+const mapStateToProps = (state) => ({
+  collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
+  collectionResourcesIds: collectionResourceIdsSelectorArray(state),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/Modals/CatalogModal.js
+++ b/src/components/Modals/CatalogModal.js
@@ -5,24 +5,24 @@ import {
 import { Entypo, Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import { connect } from 'react-redux';
 
-import { arrayOf, func, string } from 'prop-types';
+import { arrayOf, func, shape, string } from 'prop-types';
 import Colors from '../../constants/Colors';
 import BaseText from '../Generic/BaseText';
 import CollectionSegmentControl from '../SegmentControl/CollectionSegmentControl';
 import MarkedSegmentControl from '../SegmentControl/MarkedSegmentControl';
 import { clearCollection, clearMarkedResources } from '../../redux/action-creators';
-import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelectorArray } from '../../redux/selectors';
+import { collectionMarkedResourcesIdsSelector, collectionResourceIdsSelector } from '../../redux/selectors';
 
 const CatalogModal = ({
   collectionId,
   clearCollectionAction,
   clearMarkedResourcesAction,
   collectionMarkedResourcesIds,
-  collectionResourcesIds,
+  collectionResourcesIdsObjects,
 }) => {
   const [modalVisible, setModalVisible] = useState(false);
   const hasMarkedIds = collectionMarkedResourcesIds.length > 0;
-  const hasCollectionIds = collectionResourcesIds.length > 0;
+  const hasCollectionIds = Object.keys(collectionResourcesIdsObjects).length > 0;
 
   const handleClearCollection = () => {
     const clearAndCloseModal = () => {
@@ -141,7 +141,7 @@ CatalogModal.propTypes = {
   clearCollectionAction: func.isRequired,
   clearMarkedResourcesAction: func.isRequired,
   collectionMarkedResourcesIds: arrayOf(string.isRequired).isRequired,
-  collectionResourcesIds: arrayOf(string.isRequired).isRequired,
+  collectionResourcesIdsObjects: shape({}).isRequired,
 };
 
 const mapDispatchToProps = {
@@ -151,7 +151,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = (state) => ({
   collectionMarkedResourcesIds: collectionMarkedResourcesIdsSelector(state),
-  collectionResourcesIds: collectionResourceIdsSelectorArray(state),
+  collectionResourcesIdsObjects: collectionResourceIdsSelector(state),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CatalogModal);

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -35,9 +35,9 @@ CategoryButton.defaultProps = {
 };
 
 const ResourceTypeSelector = ({
-  resourceTypeFilters,
   selectResourceTypeAction,
   selectedResourceType,
+  resourceTypeFilters
 }) => (
   <View>
     <ScrollView
@@ -63,7 +63,7 @@ const ResourceTypeSelector = ({
 );
 
 ResourceTypeSelector.propTypes = {
-  resourceTypeFilters: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   selectedResourceType: string,
   selectResourceTypeAction: func.isRequired,
 };

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -37,7 +37,7 @@ CategoryButton.defaultProps = {
 const ResourceTypeSelector = ({
   selectResourceTypeAction,
   selectedResourceType,
-  resourceTypeFilters
+  resourceTypeFilters,
 }) => (
   <View>
     <ScrollView
@@ -63,7 +63,7 @@ const ResourceTypeSelector = ({
 );
 
 ResourceTypeSelector.propTypes = {
-  filteredResourceTypes: shape({}).isRequired,
+  resourceTypeFilters: shape({}).isRequired,
   selectedResourceType: string,
   selectResourceTypeAction: func.isRequired,
 };

--- a/src/components/ResourceTypeSelector/ResourceTypeSelector.js
+++ b/src/components/ResourceTypeSelector/ResourceTypeSelector.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import Colors from '../../constants/Colors';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 import { selectResourceType } from '../../redux/action-creators';
-import { activeCollectionResourceTypeFiltersSelector, activeCollectionResourceTypeSelector } from '../../redux/selectors';
+import { filteredResourceTypesSelector, activeCollectionResourceTypeSelector } from '../../redux/selectors';
 
 const CategoryButton = ({ resourceType, isActive, selectResourceTypeAction }) => {
   const categoryDisplay = PLURAL_RESOURCE_TYPES[resourceType];
@@ -37,7 +37,7 @@ CategoryButton.defaultProps = {
 const ResourceTypeSelector = ({
   selectResourceTypeAction,
   selectedResourceType,
-  resourceTypeFilters,
+  filteredResourceTypes,
 }) => (
   <View>
     <ScrollView
@@ -47,7 +47,7 @@ const ResourceTypeSelector = ({
       contentContainerStyle={styles.contentContainerStyle}
     >
       {
-        Object.entries(resourceTypeFilters)
+        Object.entries(filteredResourceTypes)
           .filter(([, isVisible]) => isVisible === true)
           .map(([resourceType]) => (
             <CategoryButton
@@ -63,7 +63,7 @@ const ResourceTypeSelector = ({
 );
 
 ResourceTypeSelector.propTypes = {
-  resourceTypeFilters: shape({}).isRequired,
+  filteredResourceTypes: shape({}).isRequired,
   selectedResourceType: string,
   selectResourceTypeAction: func.isRequired,
 };
@@ -73,7 +73,7 @@ ResourceTypeSelector.defaultProps = {
 };
 
 const mapStateToProps = (state) => ({
-  resourceTypeFilters: activeCollectionResourceTypeFiltersSelector(state),
+  filteredResourceTypes: filteredResourceTypesSelector(state),
   selectedResourceType: activeCollectionResourceTypeSelector(state),
 });
 

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { activeCollectionShowCollectionOnlySelector } from '../../redux/selectors';
+import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const collectionRecordsDescription = 'Only displays records saved to the collection.';
@@ -14,11 +15,14 @@ const collectionRecordsDescription = 'Only displays records saved to the collect
 const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowCollectionOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -36,14 +40,24 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
+  collectionDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   showCollectionOnly: activeCollectionShowCollectionOnlySelector(state),
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowCollectionOnlyAction: toggleShowCollectionOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CollectionSegmentControl);

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -16,7 +16,7 @@ const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
-  filterTriggerDateRange
+  filterTriggerDateRange,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -40,7 +40,7 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
-  collectionDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -6,8 +6,11 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
-import { actionTypes } from '../../redux/action-types';
+import { 
+  activeCollectionShowCollectionOnlySelector, 
+  // filterTriggerDateRangeSelector 
+} from '../../redux/selectors';
+// import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const collectionRecordsDescription = 'Only displays records saved to the collection.';
@@ -15,15 +18,15 @@ const collectionRecordsDescription = 'Only displays records saved to the collect
 const CollectionSegmentControl = ({
   showCollectionOnly,
   toggleShowCollectionOnlyAction,
-  updateDateRangeFilter,
-  filterTriggerDateRange,
+  // updateDateRangeFilter,
+  // filterTriggerDateRange,
   hasCollectionIds,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowCollectionOnlyAction(selectedSegmentIndex !== 0);
-    updateDateRangeFilter(filterTriggerDateRange);
+    // updateDateRangeFilter(filterTriggerDateRange);
   };
 
   // reset SegmentControl and TimelineRange when user
@@ -31,7 +34,7 @@ const CollectionSegmentControl = ({
   useEffect(() => {
     if (showCollectionOnly && !hasCollectionIds) {
       toggleShowCollectionOnlyAction(false);
-      updateDateRangeFilter(filterTriggerDateRange);
+      // updateDateRangeFilter(filterTriggerDateRange);
     }
   }, [showCollectionOnly, hasCollectionIds]);
 
@@ -51,25 +54,25 @@ const CollectionSegmentControl = ({
 CollectionSegmentControl.propTypes = {
   showCollectionOnly: bool.isRequired,
   toggleShowCollectionOnlyAction: func.isRequired,
-  filterTriggerDateRange: shape({}).isRequired,
-  updateDateRangeFilter: func.isRequired,
+  // filterTriggerDateRange: shape({}).isRequired,
+  // updateDateRangeFilter: func.isRequired,
   hasCollectionIds: bool.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showCollectionOnly: activeCollectionShowCollectionOnlySelector(state),
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  // filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {
   toggleShowCollectionOnlyAction: toggleShowCollectionOnly,
-  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
-    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
-    payload: {
-      dateRangeStart,
-      dateRangeEnd,
-    },
-  }),
+  // updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+  //   type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+  //   payload: {
+  //     dateRangeStart,
+  //     dateRangeEnd,
+  //   },
+  // }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CollectionSegmentControl);

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionResourceIdObjects
+  collectionResourceIdObjects,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -29,13 +29,14 @@ const CollectionSegmentControl = ({
   const collectionResourceIds = Object.keys(collectionResourceIdObjects)
   const isEnabled = collectionResourceIds.length > 0
 
-  // reset SegmentControl and TimelineRange when user clears Collection Records while in Show Collection Only view
+  // reset SegmentControl and TimelineRange when user
+  // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
-      toggleShowMarkedOnlyAction(false)
+    if (showCollectionOnly && collectionResourceIds.length === 0) {
+      toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [showMarkedOnly, collectionMarkedResourcesIds])
+  }, [showCollectionOnly, collectionResourceIds]);
 
   return (
     <View style={styles.root}>
@@ -55,7 +56,7 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionResourceIds: shape({}).isRequired
+  collectionResourceIdObjects: shape({}).isRequired,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -6,7 +6,7 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector, activeCollectionResourceIdsSelector } from '../../redux/selectors';
+import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionResourceIdObjects,
+  hasCollectionIds
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -26,17 +26,14 @@ const CollectionSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
 
-  const collectionResourceIds = Object.keys(collectionResourceIdObjects)
-  const isEnabled = collectionResourceIds.length > 0
-
   // reset SegmentControl and TimelineRange when user
   // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showCollectionOnly && collectionResourceIds.length === 0) {
+    if (showCollectionOnly && hasCollectionIds) {
       toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [showCollectionOnly, collectionResourceIds]);
+  }, [showCollectionOnly, hasCollectionIds]);
 
   return (
     <View style={styles.root}>
@@ -44,7 +41,7 @@ const CollectionSegmentControl = ({
         values={['All Records', 'Collection Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
-        enabled={isEnabled}
+        enabled={hasCollectionIds}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -56,13 +53,12 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionResourceIdObjects: shape({}).isRequired,
+  hasCollectionIds: bool.isRequired
 };
 
 const mapStateToProps = (state) => ({
   showCollectionOnly: activeCollectionShowCollectionOnlySelector(state),
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionResourceIdObjects: activeCollectionResourceIdsSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -17,7 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  hasCollectionIds
+  hasCollectionIds,
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -53,7 +53,7 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  hasCollectionIds: bool.isRequired
+  hasCollectionIds: bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -6,9 +6,9 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { 
-  activeCollectionShowCollectionOnlySelector, 
-  // filterTriggerDateRangeSelector 
+import {
+  activeCollectionShowCollectionOnlySelector,
+  // filterTriggerDateRangeSelector
 } from '../../redux/selectors';
 // import { actionTypes } from '../../redux/action-types';
 

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { bool, func, shape } from 'prop-types';
@@ -6,7 +6,7 @@ import BaseSegmentControl from '../Generic/BaseSegmentControl';
 
 import BaseText from '../Generic/BaseText';
 import { toggleShowCollectionOnly } from '../../redux/action-creators';
-import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { activeCollectionShowCollectionOnlySelector, filterTriggerDateRangeSelector, activeCollectionResourceIdsSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,6 +17,7 @@ const CollectionSegmentControl = ({
   toggleShowCollectionOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
+  collectionResourceIdObjects
 }) => {
   const segControlIndex = showCollectionOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : collectionRecordsDescription;
@@ -25,12 +26,24 @@ const CollectionSegmentControl = ({
     updateDateRangeFilter(filterTriggerDateRange);
   };
 
+  const collectionResourceIds = Object.keys(collectionResourceIdObjects)
+  const isEnabled = collectionResourceIds.length > 0
+
+  // reset SegmentControl and TimelineRange when user clears Collection Records while in Show Collection Only view
+  useEffect(() => {
+    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
+      toggleShowMarkedOnlyAction(false)
+      updateDateRangeFilter(filterTriggerDateRange);
+    }
+  }, [showMarkedOnly, collectionMarkedResourcesIds])
+
   return (
     <View style={styles.root}>
       <BaseSegmentControl
         values={['All Records', 'Collection Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
+        enabled={isEnabled}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -42,11 +55,13 @@ CollectionSegmentControl.propTypes = {
   toggleShowCollectionOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
+  collectionResourceIds: shape({}).isRequired
 };
 
 const mapStateToProps = (state) => ({
   showCollectionOnly: activeCollectionShowCollectionOnlySelector(state),
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  collectionResourceIdObjects: activeCollectionResourceIdsSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/CollectionSegmentControl.js
+++ b/src/components/SegmentControl/CollectionSegmentControl.js
@@ -29,7 +29,7 @@ const CollectionSegmentControl = ({
   // reset SegmentControl and TimelineRange when user
   // clears Collection Records while in Show Collection Only view
   useEffect(() => {
-    if (showCollectionOnly && hasCollectionIds) {
+    if (showCollectionOnly && !hasCollectionIds) {
       toggleShowCollectionOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import { array, bool, func, shape } from 'prop-types';
@@ -27,6 +27,14 @@ const MarkedSegmentControl = ({
   };
   const markedResourcesIds = Object.keys(markedResources)
   const isEnabled = markedResourcesIds.length > 0
+
+  // reset SegmentControl and TimelineRange when user clears Marked Records while in Show Marked Only view
+  useEffect(() => {
+    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
+      toggleShowMarkedOnlyAction(false)
+      updateDateRangeFilter(filterTriggerDateRange);
+    }
+  }, [segControlIndex, isEnabled])
 
   return (
     <View style={styles.root}>

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -17,7 +17,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  hasMarkedIds
+  hasMarkedIds,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -6,7 +6,7 @@ import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector, activeCollectionMarkedResourcesSelector } from '../../redux/selectors';
+import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,7 +17,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  collectionMarkedResources,
+  hasMarkedIds
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
@@ -25,17 +25,15 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
-  const markedResourcesIds = Object.keys(collectionMarkedResources.marked)
-  const isEnabled = markedResourcesIds.length > 0
 
   // reset SegmentControl and TimelineRange when user
   // clears Marked Records while in Show Marked Only view
   useEffect(() => {
-    if (showMarkedOnly && markedResourcesIds.length === 0) {
+    if (showMarkedOnly && !hasMarkedIds) {
       toggleShowMarkedOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [segControlIndex, isEnabled]);
+  }, [showMarkedOnly, hasMarkedIds]);
 
   return (
     <View style={styles.root}>
@@ -43,7 +41,7 @@ const MarkedSegmentControl = ({
         values={['All Records', 'Highlighted Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
-        enabled={isEnabled}
+        enabled={hasMarkedIds}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -55,13 +53,12 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  collectionMarkedResources: shape({}).isRequired
+  hasMarkedIds: bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   showMarkedOnly: activeCollectionShowMarkedOnlySelector(state),
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  collectionMarkedResources: activeCollectionMarkedResourcesSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { array, bool, func, shape } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
@@ -17,7 +17,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
-  markedResources,
+  collectionMarkedResources,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
@@ -25,16 +25,17 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
-  const markedResourcesIds = Object.keys(markedResources)
+  const markedResourcesIds = Object.keys(collectionMarkedResources.marked)
   const isEnabled = markedResourcesIds.length > 0
 
-  // reset SegmentControl and TimelineRange when user clears Marked Records while in Show Marked Only view
+  // reset SegmentControl and TimelineRange when user
+  // clears Marked Records while in Show Marked Only view
   useEffect(() => {
-    if (showMarkedOnly && collectionMarkedResourcesIds.length === 0) {
-      toggleShowMarkedOnlyAction(false)
+    if (showMarkedOnly && markedResourcesIds.length === 0) {
+      toggleShowMarkedOnlyAction(false);
       updateDateRangeFilter(filterTriggerDateRange);
     }
-  }, [segControlIndex, isEnabled])
+  }, [segControlIndex, isEnabled]);
 
   return (
     <View style={styles.root}>
@@ -54,13 +55,13 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
-  markedResources: array.isRequired
+  collectionMarkedResources: shape({}).isRequired
 };
 
 const mapStateToProps = (state) => ({
   showMarkedOnly: activeCollectionShowMarkedOnlySelector(state),
   filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
-  markedResources: activeCollectionMarkedResourcesSelector(state)
+  collectionMarkedResources: activeCollectionMarkedResourcesSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -6,9 +6,9 @@ import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { 
-  activeCollectionShowMarkedOnlySelector, 
-  // filterTriggerDateRangeSelector 
+import {
+  activeCollectionShowMarkedOnlySelector,
+  // filterTriggerDateRangeSelector
 } from '../../redux/selectors';
 // import { actionTypes } from '../../redux/action-types';
 

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { bool, func, shape } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { activeCollectionShowMarkedOnlySelector } from '../../redux/selectors';
+import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const highlightedRecordsDescription = 'Only displays highlighted records.';
@@ -14,11 +15,15 @@ const highlightedRecordsDescription = 'Only displays highlighted records.';
 const MarkedSegmentControl = ({
   showMarkedOnly,
   toggleShowMarkedOnlyAction,
+  updateDateRangeFilter,
+  filterTriggerDateRange,
 }) => {
+  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
+    updateDateRangeFilter(filterTriggerDateRange);
   };
 
   return (
@@ -36,14 +41,24 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
+  markedDateRange: shape({}).isRequired,
+  updateDateRangeFilter: func.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   showMarkedOnly: activeCollectionShowMarkedOnlySelector(state),
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
 });
 
 const mapDispatchToProps = {
   toggleShowMarkedOnlyAction: toggleShowMarkedOnly,
+  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+    payload: {
+      dateRangeStart,
+      dateRangeEnd,
+    },
+  }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarkedSegmentControl);

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -6,8 +6,11 @@ import { bool, func, shape } from 'prop-types';
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
-import { actionTypes } from '../../redux/action-types';
+import { 
+  activeCollectionShowMarkedOnlySelector, 
+  // filterTriggerDateRangeSelector 
+} from '../../redux/selectors';
+// import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
 const highlightedRecordsDescription = 'Only displays highlighted records.';
@@ -15,15 +18,15 @@ const highlightedRecordsDescription = 'Only displays highlighted records.';
 const MarkedSegmentControl = ({
   showMarkedOnly,
   toggleShowMarkedOnlyAction,
-  updateDateRangeFilter,
-  filterTriggerDateRange,
+  // updateDateRangeFilter,
+  // filterTriggerDateRange,
   hasMarkedIds,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
-    updateDateRangeFilter(filterTriggerDateRange);
+    // updateDateRangeFilter(filterTriggerDateRange);
   };
 
   // reset SegmentControl and TimelineRange when user
@@ -31,7 +34,7 @@ const MarkedSegmentControl = ({
   useEffect(() => {
     if (showMarkedOnly && !hasMarkedIds) {
       toggleShowMarkedOnlyAction(false);
-      updateDateRangeFilter(filterTriggerDateRange);
+      // updateDateRangeFilter(filterTriggerDateRange);
     }
   }, [showMarkedOnly, hasMarkedIds]);
 
@@ -51,25 +54,25 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
-  filterTriggerDateRange: shape({}).isRequired,
-  updateDateRangeFilter: func.isRequired,
+  // filterTriggerDateRange: shape({}).isRequired,
+  // updateDateRangeFilter: func.isRequired,
   hasMarkedIds: bool.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   showMarkedOnly: activeCollectionShowMarkedOnlySelector(state),
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  // filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
 });
 
 const mapDispatchToProps = {
   toggleShowMarkedOnlyAction: toggleShowMarkedOnly,
-  updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
-    type: actionTypes.UPDATE_DATE_RANGE_FILTER,
-    payload: {
-      dateRangeStart,
-      dateRangeEnd,
-    },
-  }),
+  // updateDateRangeFilter: ({ dateRangeStart, dateRangeEnd }) => ({
+  //   type: actionTypes.UPDATE_DATE_RANGE_FILTER,
+  //   payload: {
+  //     dateRangeStart,
+  //     dateRangeEnd,
+  //   },
+  // }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarkedSegmentControl);

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -18,7 +18,6 @@ const MarkedSegmentControl = ({
   updateDateRangeFilter,
   filterTriggerDateRange,
 }) => {
-  console.log('MARKED', filterTriggerDateRange)
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
   const handleChange = (selectedSegmentIndex) => {
@@ -41,7 +40,7 @@ const MarkedSegmentControl = ({
 MarkedSegmentControl.propTypes = {
   showMarkedOnly: bool.isRequired,
   toggleShowMarkedOnlyAction: func.isRequired,
-  markedDateRange: shape({}).isRequired,
+  filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
 };
 

--- a/src/components/SegmentControl/MarkedSegmentControl.js
+++ b/src/components/SegmentControl/MarkedSegmentControl.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
-import { bool, func, shape } from 'prop-types';
+import { array, bool, func, shape } from 'prop-types';
 
 import BaseSegmentControl from '../Generic/BaseSegmentControl';
 import BaseText from '../Generic/BaseText';
 import { toggleShowMarkedOnly } from '../../redux/action-creators';
-import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector } from '../../redux/selectors';
+import { activeCollectionShowMarkedOnlySelector, filterTriggerDateRangeSelector, activeCollectionMarkedResourcesSelector } from '../../redux/selectors';
 import { actionTypes } from '../../redux/action-types';
 
 const allRecordsDescription = 'Displays all records.';
@@ -17,6 +17,7 @@ const MarkedSegmentControl = ({
   toggleShowMarkedOnlyAction,
   updateDateRangeFilter,
   filterTriggerDateRange,
+  markedResources,
 }) => {
   const segControlIndex = showMarkedOnly ? 1 : 0;
   const description = segControlIndex === 0 ? allRecordsDescription : highlightedRecordsDescription;
@@ -24,6 +25,8 @@ const MarkedSegmentControl = ({
     toggleShowMarkedOnlyAction(selectedSegmentIndex !== 0);
     updateDateRangeFilter(filterTriggerDateRange);
   };
+  const markedResourcesIds = Object.keys(markedResources)
+  const isEnabled = markedResourcesIds.length > 0
 
   return (
     <View style={styles.root}>
@@ -31,6 +34,7 @@ const MarkedSegmentControl = ({
         values={['All Records', 'Highlighted Records']}
         selectedIndex={segControlIndex}
         onChange={handleChange}
+        enabled={isEnabled}
       />
       <BaseText style={styles.descriptionText}>{description}</BaseText>
     </View>
@@ -42,11 +46,13 @@ MarkedSegmentControl.propTypes = {
   toggleShowMarkedOnlyAction: func.isRequired,
   filterTriggerDateRange: shape({}).isRequired,
   updateDateRangeFilter: func.isRequired,
+  markedResources: array.isRequired
 };
 
 const mapStateToProps = (state) => ({
   showMarkedOnly: activeCollectionShowMarkedOnlySelector(state),
-  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps)
+  filterTriggerDateRange: filterTriggerDateRangeSelector(state, ownProps),
+  markedResources: activeCollectionMarkedResourcesSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -145,7 +145,6 @@ export const collectionsReducer = (state = preloadCollections, action) => {
     case actionTypes.TOGGLE_RESOURCE_TYPE_FILTERS: {
       const { collectionId, resourceType } = action.payload;
       return produce(state, (draft) => {
-        console.log('draft 2', draft[collectionId])
         const prevValue = draft[collectionId].resourceTypeFilters[resourceType];
         // eslint-disable-next-line no-param-reassign
         draft[collectionId].resourceTypeFilters[resourceType] = !prevValue;
@@ -154,7 +153,6 @@ export const collectionsReducer = (state = preloadCollections, action) => {
     case actionTypes.UPDATE_DATE_RANGE_FILTER: {
       const { collectionId, dateRangeStart, dateRangeEnd } = action.payload;
       return produce(state, (draft) => {
-        console.log('draft', draft[collectionId])
         if (dateRangeStart) {
           // eslint-disable-next-line no-param-reassign
           draft[collectionId].dateRangeFilter.dateRangeStart = dateRangeStart;

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -145,6 +145,7 @@ export const collectionsReducer = (state = preloadCollections, action) => {
     case actionTypes.TOGGLE_RESOURCE_TYPE_FILTERS: {
       const { collectionId, resourceType } = action.payload;
       return produce(state, (draft) => {
+        console.log('draft 2', draft[collectionId])
         const prevValue = draft[collectionId].resourceTypeFilters[resourceType];
         // eslint-disable-next-line no-param-reassign
         draft[collectionId].resourceTypeFilters[resourceType] = !prevValue;
@@ -153,6 +154,7 @@ export const collectionsReducer = (state = preloadCollections, action) => {
     case actionTypes.UPDATE_DATE_RANGE_FILTER: {
       const { collectionId, dateRangeStart, dateRangeEnd } = action.payload;
       return produce(state, (draft) => {
+        console.log('draft', draft[collectionId])
         if (dateRangeStart) {
           // eslint-disable-next-line no-param-reassign
           draft[collectionId].dateRangeFilter.dateRangeStart = dateRangeStart;

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -541,9 +541,9 @@ export const filterTriggerDateRangeSelector = createSelector(
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
     const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0].timelineDate),
+      dateRangeStart: startOfDay(res[0]?.timelineDate),
       dateRangeEnd: endOfDay(
-        res[res.length - 1].timelineDate,
+        res[res.length - 1]?.timelineDate,
       ),
     });
 

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -200,15 +200,6 @@ export const patientAgeAtResourcesSelector = createSelector(
   },
 );
 
-export const orderedResourceTypeFiltersSelector = createSelector(
-  [activeCollectionResourceTypeFiltersSelector],
-  (resourceTypeFilters) => Object.keys(resourceTypeFilters).sort()
-    .reduce((acc, resourceType) => {
-      acc[resourceType] = resourceTypeFilters[resourceType];
-      return acc;
-    }, {}),
-);
-
 export const lastAddedResourceIdSelector = createSelector(
   [collectionsSelector, activeCollectionIdSelector],
   (collections, activeCollectionId) => collections[activeCollectionId].lastAddedResourceId,
@@ -225,7 +216,7 @@ const subTypeResourceIdsSelector = createSelector(
   }, {}),
 );
 
-const filteredResourceTypesSelector = createSelector(
+const accordionDataBuilderSelector = createSelector(
   [
     activeCollectionResourceIdsSelector,
     activeCollectionMarkedResourcesSelector,
@@ -419,7 +410,7 @@ export const timelineIntervalsSelector = createSelector(
 
 export const accordionsContainerDataSelector = createSelector(
   [
-    filteredResourceTypesSelector,
+    accordionDataBuilderSelector,
     activeCollectionResourceTypeSelector,
     activeCollectionShowCollectionOnlySelector,
     activeCollectionShowMarkedOnlySelector,
@@ -606,10 +597,9 @@ export const filterTriggerDateRangeSelector = createSelector(
   },
 );
 
-export const resourceTypeFiltersParsedSelector = createSelector(
+const filteredResourceIdsSelector = createSelector(
   [
     resourcesSelector,
-    orderedResourceTypeFiltersSelector,
     activeCollectionResourceIdsSelector,
     activeCollectionMarkedResourcesSelector,
     collectionAndMarkedResourceIdsSelector,
@@ -618,37 +608,48 @@ export const resourceTypeFiltersParsedSelector = createSelector(
   ],
   (
     resources,
-    orderedResourceTypeFilters,
     collectionResourceIds,
     collectionMarkedResources,
     collectionAndMarkedResourceIds,
     showCollectionOnly,
     showMarkedOnly,
   ) => {
-    if (!showCollectionOnly && !showMarkedOnly) {
-      return orderedResourceTypeFilters;
-    }
-
-    let selectedIds;
     if (showCollectionOnly && !showMarkedOnly) {
-      selectedIds = Object.keys(collectionResourceIds);
-    } if (!showCollectionOnly && showMarkedOnly) {
-      selectedIds = Object.keys(collectionMarkedResources.marked);
-    } if (showCollectionOnly && showMarkedOnly) {
-      selectedIds = collectionAndMarkedResourceIds;
+      return Object.keys(collectionResourceIds)
     }
+    if (!showCollectionOnly && showMarkedOnly) {
+      return Object.keys(collectionMarkedResources.marked)
+    }
+    if (showCollectionOnly && showMarkedOnly) {
+      return collectionAndMarkedResourceIds
+    }
+    // therefore !showMarkedOnly && !showMarkedOnly
+    return Object.keys(resources)
+  }
+)
 
+export const filteredResourceTypesSelector = createSelector(
+  [
+    resourcesSelector,
+    resourceTypeFiltersSelector,
+    filteredResourceIdsSelector
+  ],
+  (
+    resources,
+    resourceTypeFilters,
+    filteredResourceIds
+  ) => {
     const resourceTypesFromSelectedIds = [];
-    selectedIds.forEach((id) => {
+    filteredResourceIds.forEach((id) => {
       const { type } = resources[id];
-      if (Object.keys(orderedResourceTypeFilters).includes(type)) {
+      if (Object.keys(resourceTypeFilters).includes(type)) {
         resourceTypesFromSelectedIds.push(type);
       }
     });
 
     return resourceTypesFromSelectedIds.sort().reduce((acc, type) => {
-      if (Object.keys(orderedResourceTypeFilters).includes(type)) {
-        acc[type] = orderedResourceTypeFilters[type];
+      if (Object.keys(resourceTypeFilters).includes(type)) {
+        acc[type] = resourceTypeFilters[type];
       }
       return acc;
     }, {});

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -62,12 +62,6 @@ export const activeCollectionResourceIdsSelector = createSelector(
   (activeCollection) => activeCollection.resourceIds,
 );
 
-// replace with activeCollectionMarkedResourcesSelector
-export const collectionMarkedResourcesIdsSelector = createSelector(
-  [collectionSelector],
-  (collection) => Object.keys(collection.markedResources.marked),
-);
-
 const collectionAndMarkedResourceIdsSelector = createSelector(
   [activeCollectionResourceIdsSelector, activeCollectionMarkedResourcesSelector],
   (collectionResourceIds, collectionMarkedResources) => {
@@ -499,15 +493,15 @@ export const accordionsContainerDataSelector = createSelector(
 export const filterTriggerDateRangeSelector = createSelector(
   [
     resourcesSelector,
-    selectedCollectionSelector,
+    activeCollectionIdSelector,
     collectionsSelector,
-    showMarkedOnlySelector,
-    showCollectionOnlySelector,
+    activeCollectionShowMarkedOnlySelector,
+    activeCollectionShowCollectionOnlySelector,
     (_, ownProps) => ownProps,
   ],
   (
     resources,
-    selectedCollectionId,
+    activeCollectionId,
     collections,
     showMarkedOnly,
     showCollectionOnly,
@@ -516,9 +510,9 @@ export const filterTriggerDateRangeSelector = createSelector(
     const { collection, marked } = ownProps;
     const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
 
-    const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
+    const collectionResourceIds = Object.keys(collections[activeCollectionId]?.resourceIds);
     const markedResourceIds = Object.keys(
-      collections[selectedCollectionId]?.markedResources?.marked,
+      collections[activeCollectionId]?.markedResources?.marked,
     );
 
     if (collection && (collectionResourceIds.length === 0)) {
@@ -609,8 +603,8 @@ const filteredResourceIdsSelector = createSelector(
     activeCollectionResourceIdsSelector,
     activeCollectionMarkedResourcesSelector,
     collectionAndMarkedResourceIdsSelector,
-    showCollectionOnlySelector,
-    showMarkedOnlySelector,
+    activeCollectionShowCollectionOnlySelector,
+    activeCollectionShowMarkedOnlySelector,
   ],
   (
     resources,
@@ -637,7 +631,7 @@ const filteredResourceIdsSelector = createSelector(
 export const filteredResourceTypesSelector = createSelector(
   [
     resourcesSelector,
-    resourceTypeFiltersSelector,
+    activeCollectionResourceTypeFiltersSelector,
     filteredResourceIdsSelector,
   ],
   (

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -120,6 +120,7 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
+    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({
@@ -132,9 +133,9 @@ export const timelinePropsSelector = createSelector(
 // either user-selected values (undefined, by default), or: min / max dates of resources
 const timelineRangeSelector = createSelector(
   [activeCollectionDateRangeFilterSelector, timelinePropsSelector],
-  (dateRangeFilterFilters, timelineProps) => {
+  (dateRangeFilters, timelineProps) => {
     const { minimumDate, maximumDate } = timelineProps;
-    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilterFilters;
+    const { dateRangeStart = minimumDate, dateRangeEnd = maximumDate } = dateRangeFilters;
     return {
       dateRangeStart,
       dateRangeEnd,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -615,29 +615,29 @@ const filteredResourceIdsSelector = createSelector(
     showMarkedOnly,
   ) => {
     if (showCollectionOnly && !showMarkedOnly) {
-      return Object.keys(collectionResourceIds)
+      return Object.keys(collectionResourceIds);
     }
     if (!showCollectionOnly && showMarkedOnly) {
-      return Object.keys(collectionMarkedResources.marked)
+      return Object.keys(collectionMarkedResources.marked);
     }
     if (showCollectionOnly && showMarkedOnly) {
-      return collectionAndMarkedResourceIds
+      return collectionAndMarkedResourceIds;
     }
     // therefore !showMarkedOnly && !showMarkedOnly
-    return Object.keys(resources)
-  }
-)
+    return Object.keys(resources);
+  },
+);
 
 export const filteredResourceTypesSelector = createSelector(
   [
     resourcesSelector,
     resourceTypeFiltersSelector,
-    filteredResourceIdsSelector
+    filteredResourceIdsSelector,
   ],
   (
     resources,
     resourceTypeFilters,
-    filteredResourceIds
+    filteredResourceIds,
   ) => {
     const resourceTypesFromSelectedIds = [];
     filteredResourceIds.forEach((id) => {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -120,7 +120,6 @@ export const sortedTimelineItemsSelector = createSelector(
 export const timelinePropsSelector = createSelector(
   [sortedTimelineItemsSelector],
   (items) => {
-    console.log('items', items)
     const r1 = items[0]; // might be same as r2
     const r2 = items[items.length - 1];
     return ({

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -62,6 +62,11 @@ export const activeCollectionResourceIdsSelector = createSelector(
   (activeCollection) => activeCollection.resourceIds,
 );
 
+export const collectionMarkedResourcesIdsSelector = createSelector(
+  [collectionSelector],
+  (collection) => Object.keys(collection.markedResources.marked),
+);
+
 const collectionAndMarkedResourceIdsSelector = createSelector(
   [activeCollectionResourceIdsSelector, activeCollectionMarkedResourcesSelector],
   (collectionResourceIds, collectionMarkedResources) => {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -488,22 +488,22 @@ export const accordionsContainerDataSelector = createSelector(
 
 export const filterTriggerDateRangeSelector = createSelector(
   [
-    resourcesSelector, 
-    selectedCollectionSelector, 
-    collectionsSelector, 
-    showMarkedOnlySelector, 
+    resourcesSelector,
+    selectedCollectionSelector,
+    collectionsSelector,
+    showMarkedOnlySelector,
     showCollectionOnlySelector,
-    (_, ownProps) => ownProps
+    (_, ownProps) => ownProps,
   ],
   (
-    resources, 
-    selectedCollectionId, 
-    collections, 
-    showMarkedOnly, 
+    resources,
+    selectedCollectionId,
+    collections,
+    showMarkedOnly,
     showCollectionOnly,
-    ownProps
+    ownProps,
   ) => {
-    const { collection, marked } = ownProps
+    const { collection, marked } = ownProps;
     const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
 
     const collectionResourceIds = Object.keys(collections[selectedCollectionId]?.resourceIds);
@@ -512,11 +512,11 @@ export const filterTriggerDateRangeSelector = createSelector(
     );
 
     if (collection && (collectionResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     if (marked && (markedResourceIds.length === 0)) {
-      return defaultTimeRange
+      return defaultTimeRange;
     }
 
     const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
@@ -525,7 +525,7 @@ export const filterTriggerDateRangeSelector = createSelector(
       }
       return acc;
     }, []);
-    
+
     const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
       if (markedResourceIds.includes(id)) {
         acc.push(resourceValues);
@@ -540,36 +540,44 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (resources) => ({
-      dateRangeStart: startOfDay(resources[0].timelineDate),
+    const createDateRange = (res) => ({
+      dateRangeStart: startOfDay(res[0].timelineDate),
       dateRangeEnd: endOfDay(
-        resources[resources.length - 1].timelineDate,
+        res[res.length - 1].timelineDate,
       ),
-    })
+    });
 
     // feed to CollectionSegmentControl
     if (collection) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after collection setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after collection setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (!showCollectionOnly && showMarkedOnly) { // after collection setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (showCollectionOnly && showMarkedOnly) { // after collection setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after collection setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
       }
     }
 
     // feed to MarkedSegmentControl
     if (marked) {
-      if (!showCollectionOnly && !showMarkedOnly) { // after setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources)
-      } else if (showCollectionOnly && !showMarkedOnly) { // after setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources)
-      } else if (!showCollectionOnly && showMarkedOnly) { // after setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange
-      } else if (showCollectionOnly && showMarkedOnly) { // after setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources)
+      if (!showCollectionOnly && !showMarkedOnly) {
+        // after setting change > !showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedMarkedResources);
+      } if (showCollectionOnly && !showMarkedOnly) {
+        // after setting change > showCollectionOnly && showMarkedOnly
+        return createDateRange(sortedCombinedResources);
+      } if (!showCollectionOnly && showMarkedOnly) {
+        // after setting change > !showCollectionOnly && !showMarkedOnly
+        return defaultTimeRange;
+      } if (showCollectionOnly && showMarkedOnly) {
+        // after setting change > showCollectionOnly && !showMarkedOnly
+        return createDateRange(sortedCollectionResources);
       }
     }
 

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -62,6 +62,7 @@ export const activeCollectionResourceIdsSelector = createSelector(
   (activeCollection) => activeCollection.resourceIds,
 );
 
+// replace with activeCollectionMarkedResourcesSelector
 export const collectionMarkedResourcesIdsSelector = createSelector(
   [collectionSelector],
   (collection) => Object.keys(collection.markedResources.marked),

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -540,12 +540,20 @@ export const filterTriggerDateRangeSelector = createSelector(
     const sortedCombinedResources = [...collectionResources, ...markedResources]
       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (res) => ({
-      dateRangeStart: startOfDay(res[0]?.timelineDate),
-      dateRangeEnd: endOfDay(
-        res[res.length - 1]?.timelineDate,
-      ),
-    });
+    const createDateRange = (res) => {
+      if (res.length === 0) {
+        return ({
+          dateRangeStart: undefined,
+          dateRangeEnd: undefined,
+        });
+      }
+      return ({
+        dateRangeStart: startOfDay(res[0]?.timelineDate),
+        dateRangeEnd: endOfDay(
+          res[res.length - 1]?.timelineDate,
+        ),
+      });
+    };
 
     // feed to CollectionSegmentControl
     if (collection) {

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -490,112 +490,112 @@ export const accordionsContainerDataSelector = createSelector(
   },
 );
 
-export const filterTriggerDateRangeSelector = createSelector(
-  [
-    resourcesSelector,
-    activeCollectionIdSelector,
-    collectionsSelector,
-    activeCollectionShowMarkedOnlySelector,
-    activeCollectionShowCollectionOnlySelector,
-    (_, ownProps) => ownProps,
-  ],
-  (
-    resources,
-    activeCollectionId,
-    collections,
-    showMarkedOnly,
-    showCollectionOnly,
-    ownProps,
-  ) => {
-    const { collection, marked } = ownProps;
-    const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
+// export const filterTriggerDateRangeSelector = createSelector(
+//   [
+//     resourcesSelector,
+//     activeCollectionIdSelector,
+//     collectionsSelector,
+//     activeCollectionShowMarkedOnlySelector,
+//     activeCollectionShowCollectionOnlySelector,
+//     (_, ownProps) => ownProps,
+//   ],
+//   (
+//     resources,
+//     activeCollectionId,
+//     collections,
+//     showMarkedOnly,
+//     showCollectionOnly,
+//     ownProps,
+//   ) => {
+//     const { collection, marked } = ownProps;
+//     const defaultTimeRange = { dateRangeStart: undefined, dateRangeEnd: undefined };
 
-    const collectionResourceIds = Object.keys(collections[activeCollectionId]?.resourceIds);
-    const markedResourceIds = Object.keys(
-      collections[activeCollectionId]?.markedResources?.marked,
-    );
+//     const collectionResourceIds = Object.keys(collections[activeCollectionId]?.resourceIds);
+//     const markedResourceIds = Object.keys(
+//       collections[activeCollectionId]?.markedResources?.marked,
+//     );
 
-    if (collection && (collectionResourceIds.length === 0)) {
-      return defaultTimeRange;
-    }
+//     if (collection && (collectionResourceIds.length === 0)) {
+//       return defaultTimeRange;
+//     }
 
-    if (marked && (markedResourceIds.length === 0)) {
-      return defaultTimeRange;
-    }
+//     if (marked && (markedResourceIds.length === 0)) {
+//       return defaultTimeRange;
+//     }
 
-    const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
-      if (collectionResourceIds.includes(id)) {
-        acc.push(resourceValues);
-      }
-      return acc;
-    }, []);
+//     const collectionResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+//       if (collectionResourceIds.includes(id)) {
+//         acc.push(resourceValues);
+//       }
+//       return acc;
+//     }, []);
 
-    const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
-      if (markedResourceIds.includes(id)) {
-        acc.push(resourceValues);
-      }
-      return acc;
-    }, []);
+//     const markedResources = Object.entries(resources).reduce((acc, [id, resourceValues]) => {
+//       if (markedResourceIds.includes(id)) {
+//         acc.push(resourceValues);
+//       }
+//       return acc;
+//     }, []);
 
-    const sortedCollectionResources = collectionResources
-      .sort((a, b) => a.timelineDate - b.timelineDate);
-    const sortedMarkedResources = markedResources
-      .sort((a, b) => a.timelineDate - b.timelineDate);
-    const sortedCombinedResources = [...collectionResources, ...markedResources]
-      .sort((a, b) => a.timelineDate - b.timelineDate);
+//     const sortedCollectionResources = collectionResources
+//       .sort((a, b) => a.timelineDate - b.timelineDate);
+//     const sortedMarkedResources = markedResources
+//       .sort((a, b) => a.timelineDate - b.timelineDate);
+//     const sortedCombinedResources = [...collectionResources, ...markedResources]
+//       .sort((a, b) => a.timelineDate - b.timelineDate);
 
-    const createDateRange = (res) => {
-      if (res.length === 0) {
-        return ({
-          dateRangeStart: undefined,
-          dateRangeEnd: undefined,
-        });
-      }
-      return ({
-        dateRangeStart: startOfDay(res[0]?.timelineDate),
-        dateRangeEnd: endOfDay(
-          res[res.length - 1]?.timelineDate,
-        ),
-      });
-    };
+//     const createDateRange = (res) => {
+//       if (res.length === 0) {
+//         return ({
+//           dateRangeStart: undefined,
+//           dateRangeEnd: undefined,
+//         });
+//       }
+//       return ({
+//         dateRangeStart: startOfDay(res[0]?.timelineDate),
+//         dateRangeEnd: endOfDay(
+//           res[res.length - 1]?.timelineDate,
+//         ),
+//       });
+//     };
 
-    // feed to CollectionSegmentControl
-    if (collection) {
-      if (!showCollectionOnly && !showMarkedOnly) {
-        // after collection setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources);
-      } if (showCollectionOnly && !showMarkedOnly) {
-        // after collection setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange;
-      } if (!showCollectionOnly && showMarkedOnly) {
-        // after collection setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources);
-      } if (showCollectionOnly && showMarkedOnly) {
-        // after collection setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources);
-      }
-    }
+//     // feed to CollectionSegmentControl
+//     if (collection) {
+//       if (!showCollectionOnly && !showMarkedOnly) {
+//         // after collection setting change > showCollectionOnly && !showMarkedOnly
+//         return createDateRange(sortedCollectionResources);
+//       } if (showCollectionOnly && !showMarkedOnly) {
+//         // after collection setting change > !showCollectionOnly && !showMarkedOnly
+//         return defaultTimeRange;
+//       } if (!showCollectionOnly && showMarkedOnly) {
+//         // after collection setting change > showCollectionOnly && showMarkedOnly
+//         return createDateRange(sortedCombinedResources);
+//       } if (showCollectionOnly && showMarkedOnly) {
+//         // after collection setting change > !showCollectionOnly && showMarkedOnly
+//         return createDateRange(sortedMarkedResources);
+//       }
+//     }
 
-    // feed to MarkedSegmentControl
-    if (marked) {
-      if (!showCollectionOnly && !showMarkedOnly) {
-        // after setting change > !showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedMarkedResources);
-      } if (showCollectionOnly && !showMarkedOnly) {
-        // after setting change > showCollectionOnly && showMarkedOnly
-        return createDateRange(sortedCombinedResources);
-      } if (!showCollectionOnly && showMarkedOnly) {
-        // after setting change > !showCollectionOnly && !showMarkedOnly
-        return defaultTimeRange;
-      } if (showCollectionOnly && showMarkedOnly) {
-        // after setting change > showCollectionOnly && !showMarkedOnly
-        return createDateRange(sortedCollectionResources);
-      }
-    }
+//     // feed to MarkedSegmentControl
+//     if (marked) {
+//       if (!showCollectionOnly && !showMarkedOnly) {
+//         // after setting change > !showCollectionOnly && showMarkedOnly
+//         return createDateRange(sortedMarkedResources);
+//       } if (showCollectionOnly && !showMarkedOnly) {
+//         // after setting change > showCollectionOnly && showMarkedOnly
+//         return createDateRange(sortedCombinedResources);
+//       } if (!showCollectionOnly && showMarkedOnly) {
+//         // after setting change > !showCollectionOnly && !showMarkedOnly
+//         return defaultTimeRange;
+//       } if (showCollectionOnly && showMarkedOnly) {
+//         // after setting change > showCollectionOnly && !showMarkedOnly
+//         return createDateRange(sortedCollectionResources);
+//       }
+//     }
 
-    return defaultTimeRange;
-  },
-);
+//     return defaultTimeRange;
+//   },
+// );
 
 const filteredResourceIdsSelector = createSelector(
   [

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -483,8 +483,8 @@ export const accordionsContainerDataSelector = createSelector(
         }
       });
     return subTypeData;
-  }
-)
+  },
+);
 
 export const filterTriggerDateRangeSelector = createSelector(
   [


### PR DESCRIPTION
- Combines #108 but triggers for `SegmentControls` to modify `DateRange` state has been commented out.
- Combines #111 which scopes `resourceTypeFilters` to just display the types belonging to `collection` or `marked` resources`
- Combines #112 which adds disabled states to `CollectionModal` actions

Note:
- `filteredResourceIdsSelector` needs to be refactored to included timeRangeFiltered items. This will resolve broken `resourceTypeFilter` scoping