### PR TITLE
Summary view record metrics

### DIFF
--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -43,10 +43,10 @@ const RecordsSummary = ({
     </View>
     <View style={styles.resourceTypeContainer}>
       <View style={styles.resourceTypeRow}>
-        <Text style={styles.resourceCountLabel} />
+        <Text style={styles.resourceCount} />
         <Text style={styles.resourceLabel} />
-        <Text style={styles.resourceDateLabel}>Oldest</Text>
-        <Text style={styles.resourceDateLabel}>Latest</Text>
+        <Text style={[styles.resourceDate, styles.tableHeading]}>Oldest</Text>
+        <Text style={[styles.resourceDate, styles.tableHeading]}>Latest</Text>
       </View>
       {recordsByType.map(({ type, label, items }) => (
         <ResourceTypeRow
@@ -119,17 +119,10 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
 
   },
-  resourceCountLabel: {
+  tableHeading: {
     color: Colors.secondary,
-    fontSize: 10,
-    alignSelf: 'flex-start',
-    flex: 1,
-  },
-  resourceDateLabel: {
-    color: Colors.secondary,
-    fontSize: 10,
+    fontSize: 12,
     alignSelf: 'flex-end',
-    flex: 1,
   },
   resourceCount: {
     alignSelf: 'flex-start',
@@ -139,10 +132,11 @@ const styles = StyleSheet.create({
   },
   resourceLabel: {
     alignSelf: 'flex-start',
-    flex: 6,
+    flex: 4,
   },
   resourceDate: {
     alignSelf: 'flex-end',
-    flex: 1,
+    fontSize: 11,
+    flex: 2,
   },
 });

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -8,10 +8,7 @@ import {
 } from 'react-native';
 import { format } from 'date-fns';
 
-import {
-  getRecordsTotal,
-} from '../../resources/fhirReader';
-import { allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
+import { allValidRecordsSortedByDateSelector, allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
 import Colors from '../../constants/Colors';
 
 const ResourceTypeRow = ({
@@ -33,43 +30,39 @@ ResourceTypeRow.propTypes = {
 };
 
 const RecordsSummary = ({
-  resources, recordsByType,
-}) => {
-  const recordsTotal = getRecordsTotal(resources);
-
-  return (
-    <View style={styles.recordSummaryContainer}>
-      <View style={styles.recordsHeader}>
-        <Text style={styles.recordsHeaderText}>
-          Records
-        </Text>
-        <Text style={styles.recordsHeaderTotal}>
-          {`${recordsTotal} Total`}
-        </Text>
-      </View>
-      <View style={styles.resourceTypeContainer}>
-        <View style={styles.resourceTypeRow}>
-          <Text style={styles.resourceCountLabel}></Text>
-          <Text style={styles.resourceName} />
-          <Text style={styles.resourceLatestDateLabel}>Oldest</Text>
-          <Text style={styles.resourceLatestDateLabel}>Latest</Text>
-        </View>
-        {recordsByType.map(({ type, label, items }) => (
-          <ResourceTypeRow
-            key={type}
-            label={label}
-            count={items.length}
-            earliestDate={items[0].timelineDate}
-            latestDate={items[items.length - 1].timelineDate}
-          />
-        ))}
-      </View>
+  allRecordsSortedByDate, recordsByType,
+}) => (
+  <View style={styles.recordSummaryContainer}>
+    <View style={styles.recordsHeader}>
+      <Text style={styles.recordsHeaderText}>
+        Records
+      </Text>
+      <Text style={styles.recordsHeaderTotal}>
+        {`${allRecordsSortedByDate.length} Total`}
+      </Text>
     </View>
-  );
-};
+    <View style={styles.resourceTypeContainer}>
+      <View style={styles.resourceTypeRow}>
+        <Text style={styles.resourceCountLabel} />
+        <Text style={styles.resourceName} />
+        <Text style={styles.resourceLatestDateLabel}>Oldest</Text>
+        <Text style={styles.resourceLatestDateLabel}>Latest</Text>
+      </View>
+      {recordsByType.map(({ type, label, items }) => (
+        <ResourceTypeRow
+          key={type}
+          label={label}
+          count={items.length}
+          earliestDate={items[0].timelineDate}
+          latestDate={items[items.length - 1].timelineDate}
+        />
+      ))}
+    </View>
+  </View>
+);
 
 RecordsSummary.propTypes = {
-  resources: shape({}),
+  allRecordsSortedByDate: arrayOf(shape({})).isRequired,
   recordsByType: arrayOf(shape({
     type: string.isRequired,
     label: string.isRequired,
@@ -78,11 +71,10 @@ RecordsSummary.propTypes = {
 };
 
 RecordsSummary.defaultProps = {
-  resources: null,
 };
 
 const mapStateToProps = (state) => ({
-  resources: state.resources,
+  allRecordsSortedByDate: allValidRecordsSortedByDateSelector(state),
   recordsByType: allValidRecordsGroupedByTypeSelector(state),
 });
 

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -16,9 +16,9 @@ const ResourceTypeRow = ({
 }) => (
   <View style={styles.resourceTypeRow}>
     <Text style={styles.resourceCount}>{count}</Text>
-    <Text style={styles.resourceName}>{label}</Text>
-    <Text style={styles.resourceLatestDate}>{format(earliestDate, 'Y')}</Text>
-    <Text style={styles.resourceLatestDate}>{format(latestDate, 'Y')}</Text>
+    <Text style={styles.resourceLabel}>{label}</Text>
+    <Text style={styles.resourceDate}>{format(earliestDate, 'MMM d, Y')}</Text>
+    <Text style={styles.resourceDate}>{format(latestDate, 'MMM d, Y')}</Text>
   </View>
 );
 
@@ -44,9 +44,9 @@ const RecordsSummary = ({
     <View style={styles.resourceTypeContainer}>
       <View style={styles.resourceTypeRow}>
         <Text style={styles.resourceCountLabel} />
-        <Text style={styles.resourceName} />
-        <Text style={styles.resourceLatestDateLabel}>Oldest</Text>
-        <Text style={styles.resourceLatestDateLabel}>Latest</Text>
+        <Text style={styles.resourceLabel} />
+        <Text style={styles.resourceDateLabel}>Oldest</Text>
+        <Text style={styles.resourceDateLabel}>Latest</Text>
       </View>
       {recordsByType.map(({ type, label, items }) => (
         <ResourceTypeRow
@@ -119,29 +119,29 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
 
   },
-  resourceName: {
+  resourceCountLabel: {
+    color: Colors.secondary,
+    fontSize: 10,
     alignSelf: 'flex-start',
-    flex: 6,
+    flex: 1,
+  },
+  resourceDateLabel: {
+    color: Colors.secondary,
+    fontSize: 10,
+    alignSelf: 'flex-end',
+    flex: 1,
   },
   resourceCount: {
-    alignSelf: 'flex-end',
+    alignSelf: 'flex-start',
     textAlign: 'left',
     paddingRight: 10,
     flex: 1,
   },
-  resourceLatestDate: {
-    alignSelf: 'flex-end',
-    flex: 1,
+  resourceLabel: {
+    alignSelf: 'flex-start',
+    flex: 6,
   },
-  resourceCountLabel: {
-    color: Colors.secondary,
-    fontSize: 10,
-    alignSelf: 'flex-end',
-    flex: 1,
-  },
-  resourceLatestDateLabel: {
-    color: Colors.secondary,
-    fontSize: 10,
+  resourceDate: {
     alignSelf: 'flex-end',
     flex: 1,
   },

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -66,7 +66,12 @@ RecordsSummary.propTypes = {
   recordsByType: arrayOf(shape({
     type: string.isRequired,
     label: string.isRequired,
-    items: arrayOf(string.isRequired).isRequired,
+    items: arrayOf(shape({
+      id: string.isRequired,
+      type: string.isRequired,
+      subType: string.isRequired,
+      timelineDate: instanceOf(Date).isRequired,
+    })).isRequired,
   })).isRequired,
 };
 

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -15,10 +15,10 @@ import { allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
 import Colors from '../../constants/Colors';
 
 const ResourceTypeRow = ({
-  total, label, earliestDate, latestDate,
+  count, label, earliestDate, latestDate,
 }) => (
   <View style={styles.resourceTypeRow}>
-    <Text style={styles.resourceCount}>{total}</Text>
+    <Text style={styles.resourceCount}>{count}</Text>
     <Text style={styles.resourceName}>{label}</Text>
     <Text style={styles.resourceLatestDate}>{format(earliestDate, 'Y')}</Text>
     <Text style={styles.resourceLatestDate}>{format(latestDate, 'Y')}</Text>
@@ -26,8 +26,8 @@ const ResourceTypeRow = ({
 );
 
 ResourceTypeRow.propTypes = {
+  count: number.isRequired,
   label: string.isRequired,
-  total: number.isRequired,
   earliestDate: instanceOf(Date).isRequired,
   latestDate: instanceOf(Date).isRequired,
 };
@@ -49,7 +49,7 @@ const RecordsSummary = ({
       </View>
       <View style={styles.resourceTypeContainer}>
         <View style={styles.resourceTypeRow}>
-          <Text style={styles.resourceCountLabel}>count</Text>
+          <Text style={styles.resourceCountLabel}></Text>
           <Text style={styles.resourceName} />
           <Text style={styles.resourceLatestDateLabel}>Oldest</Text>
           <Text style={styles.resourceLatestDateLabel}>Latest</Text>
@@ -58,7 +58,7 @@ const RecordsSummary = ({
           <ResourceTypeRow
             key={type}
             label={label}
-            total={items.length}
+            count={items.length}
             earliestDate={items[0].timelineDate}
             latestDate={items[items.length - 1].timelineDate}
           />
@@ -133,7 +133,7 @@ const styles = StyleSheet.create({
   },
   resourceCount: {
     alignSelf: 'flex-end',
-    textAlign: 'right',
+    textAlign: 'left',
     paddingRight: 10,
     flex: 1,
   },
@@ -146,13 +146,11 @@ const styles = StyleSheet.create({
     fontSize: 10,
     alignSelf: 'flex-end',
     flex: 1,
-    textTransform: 'uppercase',
   },
   resourceLatestDateLabel: {
     color: Colors.secondary,
     fontSize: 10,
     alignSelf: 'flex-end',
     flex: 1,
-    textTransform: 'uppercase',
   },
 });

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -15,11 +15,11 @@ import { allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
 import Colors from '../../constants/Colors';
 
 const ResourceTypeRow = ({
-  label, total, latestDate,
+  total, label, latestDate,
 }) => (
   <View style={styles.resourceTypeRow}>
-    <Text style={styles.resourceName}>{label}</Text>
     <Text style={styles.resourceCount}>{total}</Text>
+    <Text style={styles.resourceName}>{label}</Text>
     <Text style={styles.resourceLatestDate}>{format(latestDate, 'Y')}</Text>
   </View>
 );
@@ -48,8 +48,8 @@ const RecordsSummary = ({
       </View>
       <View style={styles.resourceTypeContainer}>
         <View style={styles.resourceTypeRow}>
-          <Text style={styles.resourceName} />
           <Text style={styles.resourceCountLabel}>count</Text>
+          <Text style={styles.resourceName} />
           <Text style={styles.resourceLatestDateLabel}>newest</Text>
         </View>
         {recordsByType.map(({ type, label, items }) => (

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -12,7 +12,7 @@ import {
   getRecordsTotal,
   getDataRange,
 } from '../../resources/fhirReader';
-import { supportedResourcesSelector } from '../../redux/selectors';
+import { allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
 import Colors from '../../constants/Colors';
 import { PLURAL_RESOURCE_TYPES } from '../../resources/resourceTypes';
 
@@ -88,7 +88,7 @@ RecordsSummary.defaultProps = {
 
 const mapStateToProps = (state) => ({
   resources: state.resources,
-  sortedResourceTypes: supportedResourcesSelector(state),
+  sortedResourceTypes: allValidRecordsGroupedByTypeSelector(state),
 });
 
 export default connect(mapStateToProps, null)(RecordsSummary);

--- a/src/components/RecordsSummary/RecordsSummary.js
+++ b/src/components/RecordsSummary/RecordsSummary.js
@@ -15,11 +15,12 @@ import { allValidRecordsGroupedByTypeSelector } from '../../redux/selectors';
 import Colors from '../../constants/Colors';
 
 const ResourceTypeRow = ({
-  total, label, latestDate,
+  total, label, earliestDate, latestDate,
 }) => (
   <View style={styles.resourceTypeRow}>
     <Text style={styles.resourceCount}>{total}</Text>
     <Text style={styles.resourceName}>{label}</Text>
+    <Text style={styles.resourceLatestDate}>{format(earliestDate, 'Y')}</Text>
     <Text style={styles.resourceLatestDate}>{format(latestDate, 'Y')}</Text>
   </View>
 );
@@ -27,7 +28,7 @@ const ResourceTypeRow = ({
 ResourceTypeRow.propTypes = {
   label: string.isRequired,
   total: number.isRequired,
-  // earliestDate: instanceOf(Date).isRequired,
+  earliestDate: instanceOf(Date).isRequired,
   latestDate: instanceOf(Date).isRequired,
 };
 
@@ -50,7 +51,8 @@ const RecordsSummary = ({
         <View style={styles.resourceTypeRow}>
           <Text style={styles.resourceCountLabel}>count</Text>
           <Text style={styles.resourceName} />
-          <Text style={styles.resourceLatestDateLabel}>newest</Text>
+          <Text style={styles.resourceLatestDateLabel}>Oldest</Text>
+          <Text style={styles.resourceLatestDateLabel}>Latest</Text>
         </View>
         {recordsByType.map(({ type, label, items }) => (
           <ResourceTypeRow

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -4,7 +4,6 @@ import thunk from 'redux-thunk';
 import authReducer from '../features/auth/authSlice';
 import {
   flattenedResourcesReducer,
-  resourceTypesReducer,
   collectionsReducer,
   activeCollectionIdReducer,
 } from './reducers';
@@ -13,7 +12,6 @@ import epicMiddleware, { rootEpic } from './epics';
 const rootReducer = combineReducers({
   auth: authReducer,
   resources: flattenedResourcesReducer,
-  resourceIdsGroupedByType: resourceTypesReducer,
   collections: collectionsReducer,
   activeCollectionId: activeCollectionIdReducer,
 });

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -23,36 +23,6 @@ export const flattenedResourcesReducer = (state = preloadedResources, action) =>
   }
 };
 
-const preloadedResourceIdsGroupedByType = {};
-
-export const resourceTypesReducer = (state = preloadedResourceIdsGroupedByType, action) => {
-  switch (action.type) {
-    case actionTypes.CLEAR_PATIENT_DATA: {
-      return preloadedResourceIdsGroupedByType;
-    }
-    case actionTypes.GROUP_BY_TYPE: {
-      const { payload } = action;
-      return Object.entries(payload).reduce((acc, [id, resource]) => {
-        const { type: resourceType, subType } = resource;
-        if (!acc[resourceType]) {
-          acc[resourceType] = {};
-        }
-        if (!acc[resourceType][subType]) {
-          acc[resourceType][subType] = new Set();
-        }
-        if (acc[resourceType][subType].has(resource.id)) {
-          console.warn(`${resourceType}--${subType} already contains ${id}`); // eslint-disable-line no-console
-        } else {
-          acc[resourceType][subType].add(resource.id);
-        }
-        return acc;
-      }, {});
-    }
-    default:
-      return state;
-  }
-};
-
 const preloadResourceTypeFilters = Object.keys(PLURAL_RESOURCE_TYPES)
   .reduce((acc, resourceType) => ({
     ...acc,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -101,7 +101,7 @@ export const providersSelector = createSelector(
 // eslint-disable-next-line max-len
 const sortEntriesByResourceType = ([t1], [t2]) => ((PLURAL_RESOURCE_TYPES[t1].toLowerCase() < PLURAL_RESOURCE_TYPES[t2].toLowerCase()) ? -1 : 1);
 
-export const supportedResourcesSelector = createSelector(
+export const allValidRecordsGroupedByTypeSelector = createSelector(
   [resourceIdsGroupedByTypeSelector],
   (resourceIdsGroupedByType) => Object.entries(resourceIdsGroupedByType)
     // do not include Patient, Observation, or unknown/unsupported:

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -112,9 +112,6 @@ export const allValidRecordsSortedByDateSelector = createSelector(
     .sort(sortByDate),
 );
 
-// eslint-disable-next-line max-len
-const sortEntriesByResourceType = ([t1], [t2]) => ((PLURAL_RESOURCE_TYPES[t1].toLowerCase() < PLURAL_RESOURCE_TYPES[t2].toLowerCase()) ? -1 : 1);
-
 export const allValidRecordsGroupedByTypeSelector = createSelector(
   [allValidRecordsSortedByDateSelector],
   (allItems) => {
@@ -128,12 +125,12 @@ export const allValidRecordsGroupedByTypeSelector = createSelector(
         });
       }, {});
     return Object.entries(typeMap)
-      .sort(sortEntriesByResourceType)
       .map(([type, items]) => ({
         type,
         label: PLURAL_RESOURCE_TYPES[type],
         items,
-      }));
+      }))
+      .sort(({ label: l1 }, { label: l2 }) => ((l1.toLowerCase() < l2.toLowerCase()) ? -1 : 1));
   },
 );
 

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -19,8 +19,6 @@ const resourcesSelector = (state) => state.resources;
 
 export const resourceByIdSelector = (state, ownProps) => state.resources[ownProps.resourceId];
 
-const resourceIdsGroupedByTypeSelector = (state) => state.resourceIdsGroupedByType;
-
 const collectionsSelector = (state) => state.collections;
 
 export const activeCollectionIdSelector = (state) => state.activeCollectionId;
@@ -61,15 +59,8 @@ export const activeCollectionShowMarkedOnlySelector = createSelector(
 );
 
 export const patientSelector = createSelector(
-  [resourcesSelector, resourceIdsGroupedByTypeSelector],
-  (resources, resourceIdsGroupedByType) => {
-    const patient = resourceIdsGroupedByType?.Patient;
-    if (!patient) {
-      return null;
-    }
-    const patientId = Array.from(patient?.Other)[0];
-    return resources[patientId];
-  },
+  [resourcesSelector],
+  (resources) => values(resources).find((r) => r.type === 'Patient'),
 );
 
 export const serviceProviderSelector = createSelector(
@@ -89,14 +80,8 @@ export const serviceProviderSelector = createSelector(
 );
 
 export const providersSelector = createSelector(
-  [resourcesSelector, resourceIdsGroupedByTypeSelector],
-  (resources, resourceIdsGroupedByType) => {
-    const serviceProviders = resourceIdsGroupedByType?.Organization?.Other;
-    if (serviceProviders) {
-      return Array.from(serviceProviders).map((id) => resources[id]);
-    }
-    return [];
-  },
+  [resourcesSelector],
+  (resources) => values(resources).filter((r) => r.type === 'Organization'),
 );
 
 const pickTimelineFields = (resource) => pick(['id', 'timelineDate', 'type', 'subType'], resource);

--- a/src/resources/fhirReader.js
+++ b/src/resources/fhirReader.js
@@ -1,25 +1,10 @@
 import {
-  format, parse, parseISO, formatDuration, intervalToDuration, compareAsc,
+  format, parse, formatDuration, intervalToDuration,
 } from 'date-fns';
 
 // date format used throughout the UI
 const UI_DATE_FORMAT = 'MMM d, Y';
 const UI_DATE_FORMAT_LONG = 'MMM d, y h:mm:ssaaa';
-
-export const getDataRange = (resourceSet, dateFormat = UI_DATE_FORMAT) => {
-  const timestamps = Object.values(resourceSet).reduce((acc, cur) => {
-    // TODO: this should consider the actual time the event happened,
-    // instead of the last resource update date, for the resources that support this
-    const date = cur.meta?.lastUpdated;
-    return acc.concat(date ? parseISO(date) : []);
-  }, [])
-    .sort(compareAsc);
-
-  return [
-    format(timestamps[0], dateFormat),
-    format(timestamps[timestamps.length - 1], dateFormat),
-  ];
-};
 
 export const getRecordsTotal = (resourceSet) => Object.keys(resourceSet).length;
 

--- a/src/resources/fhirReader.js
+++ b/src/resources/fhirReader.js
@@ -6,8 +6,6 @@ import {
 const UI_DATE_FORMAT = 'MMM d, Y';
 const UI_DATE_FORMAT_LONG = 'MMM d, y h:mm:ssaaa';
 
-export const getRecordsTotal = (resourceSet) => Object.keys(resourceSet).length;
-
 export const getPatientName = (patientResource) => {
   if (!patientResource) {
     return '';


### PR DESCRIPTION

includes:
* fixes total count (only valid records, and not Patient, or Organization)
* display correct dates for Oldest and Latest (by using `timelineDate`) 
* remove obsolete, top-level redux state: `resourceIdsGroupedByType`


basic layout:

![image](https://user-images.githubusercontent.com/3383704/115462249-6bf34b00-a1f8-11eb-8e94-ccf80d01dc6f.png)

