### PR TITLE
fix bug with react-native regex lookbehind

### DIFF
--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -68,7 +68,8 @@ export const serviceProviderSelector = createSelector(
   (resource, allResources) => {
     const ref = resource?.serviceProvider?.reference;
     if (ref) {
-      const resourceId = ref.match(/(?<=[#|/]).*/);
+      const matches = ref.match(/(#|\/)(.+)/);
+      const resourceId = matches.pop();
       const serviceProvider = allResources[resourceId];
       if (serviceProvider) {
         return serviceProvider;


### PR DESCRIPTION
react-native regexes (without debugger) do not support lookbehind.

...when the debugger is connected, lookbehind works.  (b/c the debugger [Chrome v8?] JS engine is being used?)