### PR TITLE
Create store when App component is mounted

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,7 +5,7 @@ import * as Font from 'expo-font'; // eslint-disable-line import/no-extraneous-d
 import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import Roboto from 'native-base/Fonts/Roboto.ttf';
 import Roboto_medium from 'native-base/Fonts/Roboto_medium.ttf'; // eslint-disable-line camelcase
-import store from './src/redux';
+import createStore from './src/redux';
 import RootNavigator from './src/navigation/RootNavigator';
 
 LogBox.ignoreLogs(['VirtualizedLists']);
@@ -31,7 +31,7 @@ export default function App() {
   }
 
   return (
-    <Provider store={store}>
+    <Provider store={createStore()}>
       <RootNavigator />
     </Provider>
   );

--- a/src/redux/epics/index.js
+++ b/src/redux/epics/index.js
@@ -1,7 +1,5 @@
 import { from, of } from 'rxjs';
-import {
-  createEpicMiddleware, combineEpics, ofType,
-} from 'redux-observable';
+import { combineEpics, ofType } from 'redux-observable';
 import {
   catchError, map, concatMap, switchMap, takeUntil, repeat,
 } from 'rxjs/operators';
@@ -10,7 +8,6 @@ import {
 } from 'ramda';
 
 import { actionTypes } from '../action-types';
-import FhirClient from '../middleware/fhir-client';
 import { MOCK_AUTH, MOCK_BUNDLE } from '../../components/Login/SkipLoginButton';
 
 const handleError = (error, message, type) => {
@@ -134,15 +131,11 @@ const requestReferences = (action$, state$, { fhirClient }) => action$.pipe(
   catchError((error) => handleError(error, 'Error in requestReferences concatMap')),
 );
 
-export const rootEpic = combineEpics(
+const rootEpic = combineEpics(
   initializeFhirClient,
   groupByType,
   requestNextItems,
   requestReferences,
 );
 
-export default createEpicMiddleware({
-  dependencies: {
-    fhirClient: new FhirClient(),
-  },
-});
+export default rootEpic;

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,4 +1,5 @@
 import { combineReducers, compose, configureStore } from '@reduxjs/toolkit';
+import { createEpicMiddleware } from 'redux-observable';
 import thunk from 'redux-thunk';
 
 import authReducer from '../features/auth/authSlice';
@@ -7,27 +8,38 @@ import {
   collectionsReducer,
   activeCollectionIdReducer,
 } from './reducers';
-import epicMiddleware, { rootEpic } from './epics';
+import rootEpic from './epics';
+import FhirClient from './middleware/fhir-client';
 
-const rootReducer = combineReducers({
-  auth: authReducer,
-  resources: flattenedResourcesReducer,
-  activeCollectionId: activeCollectionIdReducer,
-  collections: collectionsReducer,
-});
+const createStore = () => {
+  const epicMiddleware = createEpicMiddleware({
+    dependencies: {
+      fhirClient: new FhirClient(),
+    },
+  });
 
-const store = configureStore({
-  reducer: rootReducer,
-  middleware: compose([
-    thunk,
-    epicMiddleware,
-    // routerMiddleware(history), // < e.g.: other middleware
-  ]),
-  devTools: {
-    serialize: true, // See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize
-  },
-});
+  const rootReducer = combineReducers({
+    auth: authReducer,
+    resources: flattenedResourcesReducer,
+    activeCollectionId: activeCollectionIdReducer,
+    collections: collectionsReducer,
+  });
 
-epicMiddleware.run(rootEpic);
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: compose([
+      thunk,
+      epicMiddleware,
+      // routerMiddleware(history), // < e.g.: other middleware
+    ]),
+    devTools: {
+      serialize: true, // See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize
+    },
+  });
 
-export default store;
+  epicMiddleware.run(rootEpic);
+
+  return store;
+};
+
+export default createStore;

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -12,8 +12,8 @@ import epicMiddleware, { rootEpic } from './epics';
 const rootReducer = combineReducers({
   auth: authReducer,
   resources: flattenedResourcesReducer,
-  collections: collectionsReducer,
   activeCollectionId: activeCollectionIdReducer,
+  collections: collectionsReducer,
 });
 
 const store = configureStore({


### PR DESCRIPTION
* more adaptable, eg: for implementing persistence

* eliminates the following warning:
![image](https://user-images.githubusercontent.com/3383704/115746103-0cb14a00-a362-11eb-89b4-6ae35c666991.png)


also:

* `activeCollectionId` above `collections` in devtools:

![image](https://user-images.githubusercontent.com/3383704/115747671-7d0c9b00-a363-11eb-9609-9d2b003b5a8d.png)

