### PR TITLE
timeline chart sub-components

### DIFF
--- a/src/components/Timeline/TimelineChart/Bar.js
+++ b/src/components/Timeline/TimelineChart/Bar.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { number, string } from 'prop-types';
+import { Line } from 'react-native-svg';
+
+import * as config from './config';
+
+const Bar = ({
+  x, height, width, color,
+}) => (
+  <Line
+    x1={x}
+    y1={config.BAR_HEIGHT}
+    x2={x}
+    y2={config.BAR_HEIGHT - height}
+    stroke={color}
+    strokeWidth={width}
+    vectorEffect="non-scaling-stroke"
+    shapeRendering="crispEdges"
+  />
+);
+
+Bar.propTypes = {
+  x: number.isRequired,
+  width: number.isRequired,
+  height: number.isRequired,
+  color: string.isRequired,
+};
+
+export default Bar;

--- a/src/components/Timeline/TimelineChart/GroupingLegend.js
+++ b/src/components/Timeline/TimelineChart/GroupingLegend.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { number } from 'prop-types';
+import { Text as SvgText } from 'react-native-svg';
+import { addDays, formatDistanceStrict } from 'date-fns';
+
+import * as config from './config';
+
+const formatDays = (numDays) => {
+  const d = new Date();
+  return formatDistanceStrict(d, addDays(d, numDays), { unit: 'day' });
+};
+
+const GroupingLegend = ({
+  availableWidth,
+  intervalLength,
+}) => {
+  if (intervalLength) {
+    const intervalLengthLabel = formatDays(Math.round(intervalLength));
+    return (
+      <SvgText
+        x={availableWidth}
+        y={-16}
+        fill={config.LABEL_COLOR}
+        stroke="none"
+        fontSize={config.LABEL_FONT_SIZE}
+        textAnchor="end"
+      >
+        {`grouped by ${intervalLengthLabel}`}
+      </SvgText>
+    );
+  }
+  return null;
+};
+
+GroupingLegend.propTypes = {
+  availableWidth: number.isRequired,
+  intervalLength: number.isRequired,
+};
+
+export default GroupingLegend;

--- a/src/components/Timeline/TimelineChart/MarkedIndicators.js
+++ b/src/components/Timeline/TimelineChart/MarkedIndicators.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  arrayOf, bool, number, shape, string,
+} from 'prop-types';
+import { Rect } from 'react-native-svg';
+
+import Colors from '../../../constants/Colors';
+import * as config from './config';
+
+const getCartoucheHeight = (cardinality) => {
+  if (cardinality === 0) {
+    return 0;
+  }
+  if (cardinality === 1) {
+    return config.MARKED_RADIUS * 2; // circle
+  }
+  if (cardinality < 10) {
+    return config.MARKED_RADIUS * 3;
+  }
+  if (cardinality < 20) {
+    return config.MARKED_RADIUS * 4;
+  }
+  return config.MARKED_RADIUS * 5;
+};
+
+const MarkedCartouche = ({ hasFocused, markedHeight, y }) => (
+  <Rect
+    rx={config.MARKED_RADIUS}
+    x={config.MARKED_RADIUS * -1}
+    y={y}
+    width={config.MARKED_RADIUS * 2}
+    height={markedHeight}
+    fill={hasFocused ? Colors.hasFocused : Colors.hasMarked}
+  />
+);
+
+MarkedCartouche.propTypes = {
+  hasFocused: bool.isRequired,
+  markedHeight: number.isRequired,
+  y: number.isRequired,
+};
+
+const MarkedIndicators = ({
+  markedItems,
+}) => {
+  let nextY = config.BAR_HEIGHT + 4;
+  return markedItems.map(({ subType, marked, focused }) => {
+    const markedHeight = getCartoucheHeight(marked.length);
+    const thisY = nextY;
+    nextY += (markedHeight + 1);
+    return (
+      <MarkedCartouche
+        key={subType}
+        hasFocused={!!focused.length}
+        markedHeight={markedHeight}
+        y={thisY}
+      />
+    );
+  });
+};
+
+MarkedIndicators.propTypes = {
+  markedItems: arrayOf(shape({
+    subType: string.isRequired,
+    marked: arrayOf(string).isRequired,
+  }).isRequired).isRequired,
+};
+
+export default MarkedIndicators;

--- a/src/components/Timeline/TimelineChart/Variance.js
+++ b/src/components/Timeline/TimelineChart/Variance.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { number } from 'prop-types';
+import { Polygon } from 'react-native-svg';
+
+import * as config from './config';
+
+const Variance = ({ x, y, zScore }) => {
+  if (zScore < 1) {
+    return null;
+  }
+  return (
+    <Polygon
+      x={x}
+      y={y}
+      fill={(zScore >= 2) ? config.COLOR_2SD : config.COLOR_1SD}
+      points="-3 0, 0 -5, 3 0"
+    />
+  );
+};
+
+Variance.propTypes = {
+  x: number.isRequired,
+  y: number.isRequired,
+  zScore: number.isRequired,
+};
+
+export default Variance;

--- a/src/components/Timeline/TimelineChart/VarianceLegend.js
+++ b/src/components/Timeline/TimelineChart/VarianceLegend.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { number } from 'prop-types';
+import { Text as SvgText } from 'react-native-svg';
+
+import Variance from './Variance';
+import * as config from './config';
+
+const VarianceLegend = ({
+  maxCount, maxCount1SD, maxCount2SD, recordCount2SDplus,
+}) => {
+  if (maxCount > maxCount1SD) {
+    const between1and2SDlabel = `between ${maxCount1SD} and ${maxCount2SD}`;
+    let above2SD = null;
+
+    if (recordCount2SDplus) {
+      const above2label = `above ${maxCount2SD}`;
+      above2SD = (
+        <>
+          <Variance
+            x={120}
+            y={-16}
+            zScore={2}
+          />
+          <SvgText
+            x={126}
+            y={-16}
+            fill={config.LABEL_COLOR}
+            stroke="none"
+            fontSize={config.LABEL_FONT_SIZE}
+            textAnchor="start"
+          >
+            {above2label}
+          </SvgText>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Variance
+          x={0}
+          y={-16}
+          zScore={1}
+        />
+        <SvgText
+          x={6}
+          y={-16}
+          fill={config.LABEL_COLOR}
+          stroke="none"
+          fontSize={config.LABEL_FONT_SIZE}
+          textAnchor="start"
+        >
+          {between1and2SDlabel}
+        </SvgText>
+        {above2SD}
+      </>
+    );
+  }
+  return null;
+};
+
+VarianceLegend.propTypes = {
+  maxCount: number.isRequired,
+  maxCount1SD: number.isRequired,
+  maxCount2SD: number.isRequired,
+  recordCount2SDplus: number.isRequired,
+};
+
+export default VarianceLegend;

--- a/src/components/Timeline/TimelineChart/VerticalBound.js
+++ b/src/components/Timeline/TimelineChart/VerticalBound.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { number } from 'prop-types';
+import { Line, Text as SvgText } from 'react-native-svg';
+
+import * as config from './config';
+
+const VerticalBound = ({
+  availableWidth, countForMaxBarHeight,
+}) => {
+  if (!countForMaxBarHeight) {
+    return null;
+  }
+  const verticalBoundLabel = `${countForMaxBarHeight}`;
+  return (
+    <>
+      <Line
+        x1={0}
+        y1={-2}
+        x2={availableWidth}
+        y2={-2}
+        stroke={config.BOUNDARY_LINE_COLOR}
+        strokeDasharray="2 2"
+        strokeWidth="1"
+        vectorEffect="non-scaling-stroke"
+      />
+      <SvgText
+        fill={config.LABEL_COLOR}
+        stroke="none"
+        fontSize={config.LABEL_FONT_SIZE}
+        x={-4}
+        y={0}
+        textAnchor="end"
+      >
+        {verticalBoundLabel}
+      </SvgText>
+    </>
+  );
+};
+
+VerticalBound.propTypes = {
+  availableWidth: number.isRequired,
+  countForMaxBarHeight: number.isRequired,
+};
+
+export default VerticalBound;

--- a/src/components/Timeline/TimelineChart/XAxis.js
+++ b/src/components/Timeline/TimelineChart/XAxis.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { number, string } from 'prop-types';
+import { Line, Text as SvgText } from 'react-native-svg';
+
+import * as config from './config';
+
+const XAxis = ({ availableWidth, startLabel, endLabel }) => (
+  <>
+    <Line
+      x1={0}
+      y1={config.BAR_HEIGHT + 2}
+      x2={availableWidth}
+      y2={config.BAR_HEIGHT + 2}
+      stroke={config.BAR_COLOR}
+      strokeWidth="1"
+      vectorEffect="non-scaling-stroke"
+    />
+    <SvgText
+      fill={config.LABEL_COLOR}
+      stroke="none"
+      fontSize={config.LABEL_FONT_SIZE}
+      fontWeight="normal"
+      x={0}
+      y={config.BAR_HEIGHT + 12}
+      textAnchor="start"
+    >
+      {startLabel}
+    </SvgText>
+    <SvgText
+      fill={config.LABEL_COLOR}
+      stroke="none"
+      fontSize={config.LABEL_FONT_SIZE}
+      fontWeight="normal"
+      x={availableWidth}
+      y={config.BAR_HEIGHT + 12}
+      textAnchor="end"
+    >
+      {endLabel}
+    </SvgText>
+  </>
+);
+
+XAxis.propTypes = {
+  availableWidth: number.isRequired,
+  startLabel: string.isRequired,
+  endLabel: string.isRequired,
+};
+
+export default XAxis;

--- a/src/components/Timeline/TimelineChart/config.js
+++ b/src/components/Timeline/TimelineChart/config.js
@@ -1,0 +1,17 @@
+export const CHART_HEIGHT = 160;
+export const CHART_MARGIN = 12;
+
+export const BAR_HEIGHT = 80;
+export const BAR_WIDTH = 6;
+export const MARKED_RADIUS = BAR_WIDTH / 2;
+
+export const VARIANCE_THRESHOLD = 30;
+
+export const BOUNDARY_LINE_COLOR = '#36c';
+
+export const BAR_COLOR = '#ccc';
+export const COLOR_1SD = '#999'; // also ccc in mocks
+export const COLOR_2SD = '#f00'; // also fc0 in mocks
+
+export const LABEL_COLOR = '#333';
+export const LABEL_FONT_SIZE = 10;

--- a/src/components/Timeline/TimelineChart/index.js
+++ b/src/components/Timeline/TimelineChart/index.js
@@ -8,112 +8,15 @@ import {
 import { connect } from 'react-redux';
 import { formatDistanceStrict, addDays } from 'date-fns';
 import Svg, {
-  Rect, Line, G, Text as SvgText, Polygon, // Mask
+  Rect, Line, G, Text as SvgText, // Mask
 } from 'react-native-svg';
+
 import { timelineIntervalsSelector } from '../../../redux/selectors';
+import Bar from './Bar';
+import Variance from './Variance';
+import MarkedIndicators from './MarkedIndicators';
 import Colors from '../../../constants/Colors';
 import * as config from './config';
-
-const Variance = ({ x, y, zScore }) => {
-  if (zScore < 1) {
-    return null;
-  }
-  return (
-    <Polygon
-      x={x}
-      y={y}
-      fill={(zScore >= 2) ? config.COLOR_2SD : config.COLOR_1SD}
-      points="-3 0, 0 -5, 3 0"
-    />
-  );
-};
-
-Variance.propTypes = {
-  x: number.isRequired,
-  y: number.isRequired,
-  zScore: number.isRequired,
-};
-
-const Bar = ({
-  x, height, width, color,
-}) => (
-  <Line
-    x1={x}
-    y1={config.BAR_HEIGHT}
-    x2={x}
-    y2={config.BAR_HEIGHT - height}
-    stroke={color}
-    strokeWidth={width}
-    vectorEffect="non-scaling-stroke"
-    shapeRendering="crispEdges"
-  />
-);
-
-Bar.propTypes = {
-  x: number.isRequired,
-  width: number.isRequired,
-  height: number.isRequired,
-  color: string.isRequired,
-};
-
-const getCartoucheHeight = (cardinality) => {
-  if (cardinality === 0) {
-    return 0;
-  }
-  if (cardinality === 1) {
-    return config.MARKED_RADIUS * 2; // circle
-  }
-  if (cardinality < 10) {
-    return config.MARKED_RADIUS * 3;
-  }
-  if (cardinality < 20) {
-    return config.MARKED_RADIUS * 4;
-  }
-  return config.MARKED_RADIUS * 5;
-};
-
-const MarkedCartouche = ({ hasFocused, markedHeight, y }) => (
-  <Rect
-    rx={config.MARKED_RADIUS}
-    x={config.MARKED_RADIUS * -1}
-    y={y}
-    width={config.MARKED_RADIUS * 2}
-    height={markedHeight}
-    fill={hasFocused ? Colors.hasFocused : Colors.hasMarked}
-  />
-);
-
-MarkedCartouche.propTypes = {
-  hasFocused: bool.isRequired,
-  markedHeight: number.isRequired,
-  y: number.isRequired,
-};
-
-const MarkedIndicators = ({
-  markedItems,
-}) => {
-  let nextY = config.BAR_HEIGHT + 4;
-  return markedItems.map(({ subType, marked, focused }) => {
-    const markedHeight = getCartoucheHeight(marked.length);
-    const thisY = nextY;
-    nextY += (markedHeight + 1);
-    return (
-      <MarkedCartouche
-        key={subType}
-        hasFocused={!!focused.length}
-        markedHeight={markedHeight}
-        y={thisY}
-      />
-    );
-  });
-};
-
-MarkedIndicators.propTypes = {
-  markedItems: arrayOf(shape({
-    subType: string.isRequired,
-    marked: arrayOf(string).isRequired,
-  }).isRequired).isRequired,
-};
 
 const TimelineItems = ({
   availableWidth, countForMaxBarHeight, intervals, showVariance,

--- a/src/components/Timeline/TimelineChart/index.js
+++ b/src/components/Timeline/TimelineChart/index.js
@@ -6,13 +6,13 @@ import {
   arrayOf, instanceOf, shape, string, number, bool,
 } from 'prop-types';
 import { connect } from 'react-redux';
-import { formatDistanceStrict, addDays } from 'date-fns';
 import Svg, {
-  Rect, G, Text as SvgText, // Mask
+  Rect, G, Text as SvgText,
 } from 'react-native-svg';
 
 import { timelineIntervalsSelector } from '../../../redux/selectors';
 import VarianceLegend from './VarianceLegend';
+import GroupingLegend from './GroupingLegend';
 import VerticalBound from './VerticalBound';
 import Variance from './Variance';
 import Bar from './Bar';
@@ -71,38 +71,6 @@ TimelineItems.propTypes = {
   countForMaxBarHeight: number.isRequired,
   intervals: arrayOf(shape({})).isRequired,
   showVariance: bool.isRequired,
-};
-
-const formatDays = (numDays) => {
-  const d = new Date();
-  return formatDistanceStrict(d, addDays(d, numDays), { unit: 'day' });
-};
-
-const Metrics = ({
-  availableWidth,
-  intervalLength,
-}) => {
-  if (intervalLength) {
-    const intervalLengthLabel = formatDays(Math.round(intervalLength));
-    return (
-      <SvgText
-        x={availableWidth}
-        y={-16}
-        fill={config.LABEL_COLOR}
-        stroke="none"
-        fontSize={config.LABEL_FONT_SIZE}
-        textAnchor="end"
-      >
-        {`grouped by ${intervalLengthLabel}`}
-      </SvgText>
-    );
-  }
-  return null;
-};
-
-Metrics.propTypes = {
-  availableWidth: number.isRequired,
-  intervalLength: number.isRequired,
 };
 
 const TimelineChart = ({ timelineIntervals }) => {
@@ -169,7 +137,7 @@ const TimelineChart = ({ timelineIntervals }) => {
             recordCount2SDplus={recordCount2SDplus}
           />
           )}
-          <Metrics
+          <GroupingLegend
             availableWidth={availableWidth}
             intervalLength={intervalLength}
           />

--- a/src/components/Timeline/TimelineChart/index.js
+++ b/src/components/Timeline/TimelineChart/index.js
@@ -12,19 +12,7 @@ import Svg, {
 } from 'react-native-svg';
 import { timelineIntervalsSelector } from '../../../redux/selectors';
 import Colors from '../../../constants/Colors';
-
-const VARIANCE_THRESHOLD = 30;
-const BAR_COLOR = '#ccc';
-const COLOR_1SD = '#999'; // also ccc in mocks
-const COLOR_2SD = '#f00'; // also fc0 in mocks
-const BOUNDARY_LINE_COLOR = '#36c';
-const CHART_MARGIN = 12;
-export const CHART_HEIGHT = 160;
-const BAR_HEIGHT = 80;
-const BAR_WIDTH = 6;
-const LABEL_COLOR = '#333';
-const LABEL_FONT_SIZE = 10;
-const MARKED_RADIUS = BAR_WIDTH / 2;
+import * as config from './config';
 
 const Variance = ({ x, y, zScore }) => {
   if (zScore < 1) {
@@ -34,7 +22,7 @@ const Variance = ({ x, y, zScore }) => {
     <Polygon
       x={x}
       y={y}
-      fill={(zScore >= 2) ? COLOR_2SD : COLOR_1SD}
+      fill={(zScore >= 2) ? config.COLOR_2SD : config.COLOR_1SD}
       points="-3 0, 0 -5, 3 0"
     />
   );
@@ -51,9 +39,9 @@ const Bar = ({
 }) => (
   <Line
     x1={x}
-    y1={BAR_HEIGHT}
+    y1={config.BAR_HEIGHT}
     x2={x}
-    y2={BAR_HEIGHT - height}
+    y2={config.BAR_HEIGHT - height}
     stroke={color}
     strokeWidth={width}
     vectorEffect="non-scaling-stroke"
@@ -73,23 +61,23 @@ const getCartoucheHeight = (cardinality) => {
     return 0;
   }
   if (cardinality === 1) {
-    return MARKED_RADIUS * 2; // circle
+    return config.MARKED_RADIUS * 2; // circle
   }
   if (cardinality < 10) {
-    return MARKED_RADIUS * 3;
+    return config.MARKED_RADIUS * 3;
   }
   if (cardinality < 20) {
-    return MARKED_RADIUS * 4;
+    return config.MARKED_RADIUS * 4;
   }
-  return MARKED_RADIUS * 5;
+  return config.MARKED_RADIUS * 5;
 };
 
 const MarkedCartouche = ({ hasFocused, markedHeight, y }) => (
   <Rect
-    rx={MARKED_RADIUS}
-    x={MARKED_RADIUS * -1}
+    rx={config.MARKED_RADIUS}
+    x={config.MARKED_RADIUS * -1}
     y={y}
-    width={MARKED_RADIUS * 2}
+    width={config.MARKED_RADIUS * 2}
     height={markedHeight}
     fill={hasFocused ? Colors.hasFocused : Colors.hasMarked}
   />
@@ -104,7 +92,7 @@ MarkedCartouche.propTypes = {
 const MarkedIndicators = ({
   markedItems,
 }) => {
-  let nextY = BAR_HEIGHT + 4;
+  let nextY = config.BAR_HEIGHT + 4;
   return markedItems.map(({ subType, marked, focused }) => {
     const markedHeight = getCartoucheHeight(marked.length);
     const thisY = nextY;
@@ -133,7 +121,7 @@ const TimelineItems = ({
   if (!countForMaxBarHeight) {
     return null;
   }
-  const tickUnits = BAR_HEIGHT / countForMaxBarHeight;
+  const tickUnits = config.BAR_HEIGHT / countForMaxBarHeight;
 
   return intervals
     .filter(({ items }) => !!items.length)
@@ -153,14 +141,14 @@ const TimelineItems = ({
         )}
         <Bar
           x={0}
-          width={BAR_WIDTH}
+          width={config.BAR_WIDTH}
           height={Math.max(Math.min(items.length, countForMaxBarHeight) * tickUnits, 4)}
-          color={BAR_COLOR}
+          color={config.BAR_COLOR}
         />
         {!collectionItems.length ? null : (
           <Bar
             x={0}
-            width={BAR_WIDTH}
+            width={config.BAR_WIDTH}
             height={Math.max(Math.min(collectionItems.length, countForMaxBarHeight) * tickUnits, 4)}
             color={Colors.collectionIcon}
           />
@@ -183,31 +171,31 @@ const XAxis = ({ availableWidth, startLabel, endLabel }) => (
   <>
     <Line
       x1={0}
-      y1={BAR_HEIGHT + 2}
+      y1={config.BAR_HEIGHT + 2}
       x2={availableWidth}
-      y2={BAR_HEIGHT + 2}
-      stroke={BAR_COLOR}
+      y2={config.BAR_HEIGHT + 2}
+      stroke={config.BAR_COLOR}
       strokeWidth="1"
       vectorEffect="non-scaling-stroke"
     />
     <SvgText
-      fill={LABEL_COLOR}
+      fill={config.LABEL_COLOR}
       stroke="none"
-      fontSize={LABEL_FONT_SIZE}
+      fontSize={config.LABEL_FONT_SIZE}
       fontWeight="normal"
       x={0}
-      y={BAR_HEIGHT + 12}
+      y={config.BAR_HEIGHT + 12}
       textAnchor="start"
     >
       {startLabel}
     </SvgText>
     <SvgText
-      fill={LABEL_COLOR}
+      fill={config.LABEL_COLOR}
       stroke="none"
-      fontSize={LABEL_FONT_SIZE}
+      fontSize={config.LABEL_FONT_SIZE}
       fontWeight="normal"
       x={availableWidth}
-      y={BAR_HEIGHT + 12}
+      y={config.BAR_HEIGHT + 12}
       textAnchor="end"
     >
       {endLabel}
@@ -235,15 +223,15 @@ const VerticalBound = ({
         y1={-2}
         x2={availableWidth}
         y2={-2}
-        stroke={BOUNDARY_LINE_COLOR}
+        stroke={config.BOUNDARY_LINE_COLOR}
         strokeDasharray="2 2"
         strokeWidth="1"
         vectorEffect="non-scaling-stroke"
       />
       <SvgText
-        fill={LABEL_COLOR}
+        fill={config.LABEL_COLOR}
         stroke="none"
-        fontSize={LABEL_FONT_SIZE}
+        fontSize={config.LABEL_FONT_SIZE}
         x={-4}
         y={0}
         textAnchor="end"
@@ -278,9 +266,9 @@ const VarianceLegend = ({
           <SvgText
             x={126}
             y={-16}
-            fill={LABEL_COLOR}
+            fill={config.LABEL_COLOR}
             stroke="none"
-            fontSize={LABEL_FONT_SIZE}
+            fontSize={config.LABEL_FONT_SIZE}
             textAnchor="start"
           >
             {above2label}
@@ -299,9 +287,9 @@ const VarianceLegend = ({
         <SvgText
           x={6}
           y={-16}
-          fill={LABEL_COLOR}
+          fill={config.LABEL_COLOR}
           stroke="none"
-          fontSize={LABEL_FONT_SIZE}
+          fontSize={config.LABEL_FONT_SIZE}
           textAnchor="start"
         >
           {between1and2SDlabel}
@@ -335,9 +323,9 @@ const Metrics = ({
       <SvgText
         x={availableWidth}
         y={-16}
-        fill={LABEL_COLOR}
+        fill={config.LABEL_COLOR}
         stroke="none"
-        fontSize={LABEL_FONT_SIZE}
+        fontSize={config.LABEL_FONT_SIZE}
         textAnchor="end"
       >
         {`grouped by ${intervalLengthLabel}`}
@@ -358,10 +346,10 @@ const TimelineChart = ({ timelineIntervals }) => {
     intervals, intervalLength,
   } = timelineIntervals;
   const screenWidth = Dimensions.get('window').width;
-  const availableWidth = screenWidth - (3 * CHART_MARGIN);
+  const availableWidth = screenWidth - (3 * config.CHART_MARGIN);
   // TODO: a full, multi-line description of applied filters?
   const noResultsMessage = recordCount ? '' : 'No loaded records pass your filters.';
-  const showVariance = maxCount > VARIANCE_THRESHOLD;
+  const showVariance = maxCount > config.VARIANCE_THRESHOLD;
   const countForMaxBarHeight = showVariance ? maxCount1SD : maxCount;
 
   return (
@@ -373,22 +361,22 @@ const TimelineChart = ({ timelineIntervals }) => {
     >
       <Svg
         width={`${screenWidth}`}
-        height={CHART_HEIGHT}
-        viewBox={`0 0 ${screenWidth} ${CHART_HEIGHT}`}
+        height={config.CHART_HEIGHT}
+        viewBox={`0 0 ${screenWidth} ${config.CHART_HEIGHT}`}
         style={{ borderWidth: 0 }}
       >
         <G
-          x={2 * CHART_MARGIN} // accommodate label for boundary line
+          x={2 * config.CHART_MARGIN} // accommodate label for boundary line
           y={32}
         >
           <SvgText
-            fill={LABEL_COLOR}
+            fill={config.LABEL_COLOR}
             stroke="none"
             fontSize="12"
             fontWeight="bold"
             fontStyle="italic"
             x={availableWidth / 2}
-            y={BAR_HEIGHT / 2}
+            y={config.BAR_HEIGHT / 2}
             textAnchor="middle"
           >
             {noResultsMessage}
@@ -424,7 +412,7 @@ const TimelineChart = ({ timelineIntervals }) => {
             x="0"
             y="0"
             width={availableWidth}
-            height={BAR_HEIGHT}
+            height={config.BAR_HEIGHT}
             strokeDasharray="2 2"
             // stroke="#f008" // debug position
           />
@@ -433,7 +421,7 @@ const TimelineChart = ({ timelineIntervals }) => {
           x="0"
           y="0"
           width={screenWidth}
-          height={CHART_HEIGHT}
+          height={config.CHART_HEIGHT}
           strokeDasharray="2 2"
           // stroke="#00f8" // debug position
         />
@@ -477,7 +465,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(React.memo(TimelineC
 const styles = StyleSheet.create({
   root: {
     width: '100%',
-    minHeight: CHART_HEIGHT,
+    minHeight: config.CHART_HEIGHT,
   },
   debug: {
     left: 2,

--- a/src/components/Timeline/TimelineChart/index.js
+++ b/src/components/Timeline/TimelineChart/index.js
@@ -10,8 +10,8 @@ import { formatDistanceStrict, addDays } from 'date-fns';
 import Svg, {
   Rect, Line, G, Text as SvgText, Polygon, // Mask
 } from 'react-native-svg';
-import { timelineIntervalsSelector } from '../../redux/selectors';
-import Colors from '../../constants/Colors';
+import { timelineIntervalsSelector } from '../../../redux/selectors';
+import Colors from '../../../constants/Colors';
 
 const VARIANCE_THRESHOLD = 30;
 const BAR_COLOR = '#ccc';
@@ -352,7 +352,7 @@ Metrics.propTypes = {
   intervalLength: number.isRequired,
 };
 
-const TimelineBrowser = ({ timelineIntervals }) => {
+const TimelineChart = ({ timelineIntervals }) => {
   const {
     maxCount, maxCount1SD, maxCount2SD, recordCount, recordCount2SDplus,
     intervals, intervalLength,
@@ -442,7 +442,7 @@ const TimelineBrowser = ({ timelineIntervals }) => {
   );
 };
 
-TimelineBrowser.propTypes = {
+TimelineChart.propTypes = {
   timelineIntervals: shape({
     startDate: instanceOf(Date),
     maxDate: instanceOf(Date),
@@ -472,7 +472,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(React.memo(TimelineBrowser));
+export default connect(mapStateToProps, mapDispatchToProps)(React.memo(TimelineChart));
 
 const styles = StyleSheet.create({
   root: {

--- a/src/components/Timeline/TimelineChart/index.js
+++ b/src/components/Timeline/TimelineChart/index.js
@@ -8,12 +8,15 @@ import {
 import { connect } from 'react-redux';
 import { formatDistanceStrict, addDays } from 'date-fns';
 import Svg, {
-  Rect, Line, G, Text as SvgText, // Mask
+  Rect, G, Text as SvgText, // Mask
 } from 'react-native-svg';
 
 import { timelineIntervalsSelector } from '../../../redux/selectors';
-import Bar from './Bar';
+import VarianceLegend from './VarianceLegend';
+import VerticalBound from './VerticalBound';
 import Variance from './Variance';
+import Bar from './Bar';
+import XAxis from './XAxis';
 import MarkedIndicators from './MarkedIndicators';
 import Colors from '../../../constants/Colors';
 import * as config from './config';
@@ -68,147 +71,6 @@ TimelineItems.propTypes = {
   countForMaxBarHeight: number.isRequired,
   intervals: arrayOf(shape({})).isRequired,
   showVariance: bool.isRequired,
-};
-
-const XAxis = ({ availableWidth, startLabel, endLabel }) => (
-  <>
-    <Line
-      x1={0}
-      y1={config.BAR_HEIGHT + 2}
-      x2={availableWidth}
-      y2={config.BAR_HEIGHT + 2}
-      stroke={config.BAR_COLOR}
-      strokeWidth="1"
-      vectorEffect="non-scaling-stroke"
-    />
-    <SvgText
-      fill={config.LABEL_COLOR}
-      stroke="none"
-      fontSize={config.LABEL_FONT_SIZE}
-      fontWeight="normal"
-      x={0}
-      y={config.BAR_HEIGHT + 12}
-      textAnchor="start"
-    >
-      {startLabel}
-    </SvgText>
-    <SvgText
-      fill={config.LABEL_COLOR}
-      stroke="none"
-      fontSize={config.LABEL_FONT_SIZE}
-      fontWeight="normal"
-      x={availableWidth}
-      y={config.BAR_HEIGHT + 12}
-      textAnchor="end"
-    >
-      {endLabel}
-    </SvgText>
-  </>
-);
-
-XAxis.propTypes = {
-  availableWidth: number.isRequired,
-  startLabel: string.isRequired,
-  endLabel: string.isRequired,
-};
-
-const VerticalBound = ({
-  availableWidth, countForMaxBarHeight,
-}) => {
-  if (!countForMaxBarHeight) {
-    return null;
-  }
-  const verticalBoundLabel = `${countForMaxBarHeight}`;
-  return (
-    <>
-      <Line
-        x1={0}
-        y1={-2}
-        x2={availableWidth}
-        y2={-2}
-        stroke={config.BOUNDARY_LINE_COLOR}
-        strokeDasharray="2 2"
-        strokeWidth="1"
-        vectorEffect="non-scaling-stroke"
-      />
-      <SvgText
-        fill={config.LABEL_COLOR}
-        stroke="none"
-        fontSize={config.LABEL_FONT_SIZE}
-        x={-4}
-        y={0}
-        textAnchor="end"
-      >
-        {verticalBoundLabel}
-      </SvgText>
-    </>
-  );
-};
-
-VerticalBound.propTypes = {
-  availableWidth: number.isRequired,
-  countForMaxBarHeight: number.isRequired,
-};
-
-const VarianceLegend = ({
-  maxCount, maxCount1SD, maxCount2SD, recordCount2SDplus,
-}) => {
-  if (maxCount > maxCount1SD) {
-    const between1and2SDlabel = `between ${maxCount1SD} and ${maxCount2SD}`;
-    let above2SD = null;
-
-    if (recordCount2SDplus) {
-      const above2label = `above ${maxCount2SD}`;
-      above2SD = (
-        <>
-          <Variance
-            x={120}
-            y={-16}
-            zScore={2}
-          />
-          <SvgText
-            x={126}
-            y={-16}
-            fill={config.LABEL_COLOR}
-            stroke="none"
-            fontSize={config.LABEL_FONT_SIZE}
-            textAnchor="start"
-          >
-            {above2label}
-          </SvgText>
-        </>
-      );
-    }
-
-    return (
-      <>
-        <Variance
-          x={0}
-          y={-16}
-          zScore={1}
-        />
-        <SvgText
-          x={6}
-          y={-16}
-          fill={config.LABEL_COLOR}
-          stroke="none"
-          fontSize={config.LABEL_FONT_SIZE}
-          textAnchor="start"
-        >
-          {between1and2SDlabel}
-        </SvgText>
-        {above2SD}
-      </>
-    );
-  }
-  return null;
-};
-
-VarianceLegend.propTypes = {
-  maxCount: number.isRequired,
-  maxCount1SD: number.isRequired,
-  maxCount2SD: number.isRequired,
-  recordCount2SDplus: number.isRequired,
 };
 
 const formatDays = (numDays) => {

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -4,7 +4,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons'; // eslint-disable-line import/no-extraneous-dependencies
 import DateRangePicker from './DateRangePicker';
-import TimelineBrowser from './TimelineBrowser';
+import TimelineChart from './TimelineChart';
 
 import Colors from '../../constants/Colors';
 
@@ -26,7 +26,7 @@ const Timeline = () => {
           {expandIcon}
         </TouchableOpacity>
       </View>
-      {showTimeline && <TimelineBrowser />}
+      {showTimeline && <TimelineChart />}
     </View>
   );
 };

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -10,9 +10,6 @@ import Colors from '../../constants/Colors';
 
 const Timeline = () => {
   const [showTimeline, setShowTimeline] = useState(true);
-  const expandIcon = showTimeline
-    ? <Ionicons name="chevron-up" size={24} color={Colors.expandTimeline} />
-    : <Ionicons name="chevron-down" size={24} color={Colors.expandTimeline} />;
 
   return (
     <View style={styles.root}>
@@ -23,7 +20,11 @@ const Timeline = () => {
           style={styles.iconContainer}
           onPress={() => setShowTimeline(!showTimeline)}
         >
-          {expandIcon}
+          <Ionicons
+            name={showTimeline ? 'chevron-up' : 'chevron-down'}
+            size={24}
+            color={Colors.expandTimeline}
+          />
         </TouchableOpacity>
       </View>
       {showTimeline && <TimelineChart />}


### PR DESCRIPTION
This PR is in support of:
* responsive x-axis date labels 
* moving the type-filter icon

rename to `TimelineChart`, and break-out sub-components as follows:
![image](https://user-images.githubusercontent.com/3383704/117689199-83827b80-b187-11eb-9d70-cc593d7ae460.png)

The underlying implementations should be identical.