### PR TITLE
Reset Async Storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-app-auth": "~9.3.0",
     "expo-linking": "~2.0.0",
     "expo-status-bar": "~1.0.3",
+    "expo-updates": "~0.4.1",
     "fhir-kit-client": "^1.6.5",
     "immer": "^9.0.1",
     "native-base": "^2.15.2",

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  StyleSheet, Text, View, TouchableOpacity, Button
+  StyleSheet, Text, View, TouchableOpacity, Button,
 } from 'react-native';
 import * as Updates from 'expo-updates';
 import AsyncStorage from '@react-native-async-storage/async-storage';

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -8,13 +8,15 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 
 import Storage from '../../storage';
 import Colors from '../../constants/Colors';
-import { onboardingState, storageOnboardingState, storageOnboardingToggleCount, onboardingToggleCount } from '../../recoil';
+import {
+  onboardingState, storageOnboardingState, storageOnboardingToggleCount, onboardingToggleCount,
+} from '../../recoil';
 
 const OnboardingToggleButton = () => {
   const storageIsOBComplete = useRecoilValue(storageOnboardingState);
   const [isOnboardingComplete, setIsOnboardingComplete] = useRecoilState(onboardingState(storageIsOBComplete)); // eslint-disable-line max-len
   const storageOBToggleCount = useRecoilValue(storageOnboardingToggleCount);
-  const [obToggleCount, setOnboardingToggleCount] = useRecoilState(onboardingToggleCount(storageOBToggleCount));
+  const [obToggleCount, setOnboardingToggleCount] = useRecoilState(onboardingToggleCount(storageOBToggleCount)); // eslint-disable-line max-len
 
   const handleOnboardingToggle = ({ isCompleted, newCount }) => {
     Storage.setOnboardingState(isCompleted);

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import {
-  StyleSheet, Text, View, TouchableOpacity,
+  StyleSheet, Text, View, TouchableOpacity, Button
 } from 'react-native';
-import { useRecoilValue, useRecoilState } from 'recoil';
+import * as Updates from 'expo-updates';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import Storage from '../../storage';
 import Colors from '../../constants/Colors';
@@ -15,6 +16,11 @@ const OnboardingToggleButton = () => {
   const handleOnboardingToggle = (isCompleted) => {
     Storage.setOnboardingState(isCompleted);
     setIsOnboardingComplete(isCompleted);
+  };
+
+  const handleClearAsyncStorage = async () => {
+    await AsyncStorage.clear();
+    Updates.reloadAsync();
   };
 
   return (
@@ -30,6 +36,7 @@ const OnboardingToggleButton = () => {
           Times Onboarding Button Toggled:
           {onboardingToggleCount}
         </Text>
+        <Button title="Reset Async Storage" onPress={handleClearAsyncStorage} />
       </View>
     </View>
   );

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -4,7 +4,7 @@ import {
 } from 'react-native';
 import * as Updates from 'expo-updates';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {useRecoilValue, useRecoilState} from 'recoil'
+import { useRecoilValue, useRecoilState } from 'recoil';
 
 import Storage from '../../storage';
 import Colors from '../../constants/Colors';

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -8,12 +8,13 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 
 import Storage from '../../storage';
 import Colors from '../../constants/Colors';
-import { onboardingState, storageOnboardingState, onboardingToggleCount as rOnboardingToggleCount } from '../../recoil';
+import { onboardingState, storageOnboardingState, storageOnboardingToggleCount, onboardingToggleCount } from '../../recoil';
 
 const OnboardingToggleButton = () => {
   const storageIsOBComplete = useRecoilValue(storageOnboardingState);
   const [isOnboardingComplete, setIsOnboardingComplete] = useRecoilState(onboardingState(storageIsOBComplete)); // eslint-disable-line max-len
-  const [onboardingToggleCount, setOnboardingToggleCount] = useRecoilState(rOnboardingToggleCount);
+  const storageOBToggleCount = useRecoilValue(storageOnboardingToggleCount);
+  const [obToggleCount, setOnboardingToggleCount] = useRecoilState(onboardingToggleCount(storageOBToggleCount));
 
   const handleOnboardingToggle = ({ isCompleted, newCount }) => {
     Storage.setOnboardingState(isCompleted);
@@ -34,14 +35,14 @@ const OnboardingToggleButton = () => {
           style={styles.onboardingButton}
           onPress={() => handleOnboardingToggle({
             isCompleted: !isOnboardingComplete,
-            newCount: onboardingToggleCount + 1,
+            newCount: obToggleCount + 1,
           })}
         >
           <Text style={styles.onboardingButtonText}>{`Onboarding Completed: ${JSON.stringify(isOnboardingComplete)}`}</Text>
         </TouchableOpacity>
         <Text style={{ marginTop: 10 }}>
           Times Onboarding Button Toggled:
-          {onboardingToggleCount}
+          {obToggleCount}
         </Text>
         <Button title="Reset Async Storage" onPress={handleClearAsyncStorage} />
       </View>

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -4,18 +4,22 @@ import {
 } from 'react-native';
 import * as Updates from 'expo-updates';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {useRecoilValue, useRecoilState} from 'recoil'
 
 import Storage from '../../storage';
 import Colors from '../../constants/Colors';
-import { onboardingState, storageOnboardingState } from '../../recoil';
+import { onboardingState, storageOnboardingState, onboardingToggleCount as rOnboardingToggleCount } from '../../recoil';
 
 const OnboardingToggleButton = () => {
   const storageIsOBComplete = useRecoilValue(storageOnboardingState);
   const [isOnboardingComplete, setIsOnboardingComplete] = useRecoilState(onboardingState(storageIsOBComplete)); // eslint-disable-line max-len
+  const [onboardingToggleCount, setOnboardingToggleCount] = useRecoilState(rOnboardingToggleCount);
 
-  const handleOnboardingToggle = (isCompleted) => {
+  const handleOnboardingToggle = ({ isCompleted, newCount }) => {
     Storage.setOnboardingState(isCompleted);
     setIsOnboardingComplete(isCompleted);
+    Storage.setOnboardingToggleCount(newCount);
+    setOnboardingToggleCount(newCount);
   };
 
   const handleClearAsyncStorage = async () => {
@@ -28,11 +32,14 @@ const OnboardingToggleButton = () => {
       <View style={styles.onboardingContainer}>
         <TouchableOpacity
           style={styles.onboardingButton}
-          onPress={() => handleOnboardingToggle(!isOnboardingComplete)}
+          onPress={() => handleOnboardingToggle({
+            isCompleted: !isOnboardingComplete,
+            newCount: onboardingToggleCount + 1,
+          })}
         >
           <Text style={styles.onboardingButtonText}>{`Onboarding Completed: ${JSON.stringify(isOnboardingComplete)}`}</Text>
         </TouchableOpacity>
-        <Text>
+        <Text style={{ marginTop: 10 }}>
           Times Onboarding Button Toggled:
           {onboardingToggleCount}
         </Text>

--- a/src/components/Onboarding/OnboardingToggleButton.js
+++ b/src/components/Onboarding/OnboardingToggleButton.js
@@ -26,6 +26,10 @@ const OnboardingToggleButton = () => {
         >
           <Text style={styles.onboardingButtonText}>{`Onboarding Completed: ${JSON.stringify(isOnboardingComplete)}`}</Text>
         </TouchableOpacity>
+        <Text>
+          Times Onboarding Button Toggled:
+          {onboardingToggleCount}
+        </Text>
       </View>
     </View>
   );

--- a/src/recoil.js
+++ b/src/recoil.js
@@ -17,7 +17,6 @@ export const storageOnboardingState = selector({
   get: async () => Storage.getOnboardingState(),
 });
 
-
 export const onboardingState = memoizeWith(identity, (storageIsOnboardingComplete) => {
   const atomForOnboardingState = atom({
     key: 'atomForOnboardingState',
@@ -47,9 +46,9 @@ export const onboardingToggleCount = memoizeWith(identity, (storageOBToggleCount
 
   return selector({
     key: 'onboardingToggleCount',
-    get: ({ get }) => get(atomForOnboardingToggleCount) === undefined 
-      ? storageOBToggleCount 
-      : get(atomForOnboardingToggleCount),
+    get: ({ get }) => (get(atomForOnboardingToggleCount) === undefined
+      ? storageOBToggleCount
+      : get(atomForOnboardingToggleCount)),
     set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount),
-  })
+  });
 });

--- a/src/recoil.js
+++ b/src/recoil.js
@@ -32,3 +32,14 @@ export const onboardingState = memoizeWith(identity, (storageIsOnboardingComplet
     set: ({ set }, isCompleted) => set(atomForOnboardingState, isCompleted),
   });
 });
+
+const atomForOnboardingToggleCount = atom({
+  key: 'atomForOnboardingToggleCount',
+  default: 0,
+});
+
+export const onboardingToggleCount = selector({
+  key: 'onboardingToggleCount',
+  get: ({ get }) => get(atomForOnboardingToggleCount),
+  set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount)}
+);

--- a/src/recoil.js
+++ b/src/recoil.js
@@ -17,6 +17,7 @@ export const storageOnboardingState = selector({
   get: async () => Storage.getOnboardingState(),
 });
 
+
 export const onboardingState = memoizeWith(identity, (storageIsOnboardingComplete) => {
   const atomForOnboardingState = atom({
     key: 'atomForOnboardingState',
@@ -33,13 +34,22 @@ export const onboardingState = memoizeWith(identity, (storageIsOnboardingComplet
   });
 });
 
-const atomForOnboardingToggleCount = atom({
-  key: 'atomForOnboardingToggleCount',
-  default: 0,
+export const storageOnboardingToggleCount = selector({
+  key: 'storageOnboardingToggleCount',
+  get: async () => Storage.getOnboardingToggleCount(),
 });
 
-export const onboardingToggleCount = selector({
-  key: 'onboardingToggleCount',
-  get: ({ get }) => get(atomForOnboardingToggleCount),
-  set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount),
+export const onboardingToggleCount = memoizeWith(identity, (storageOBToggleCount) => {
+  const atomForOnboardingToggleCount = atom({
+    key: 'atomForOnboardingToggleCount',
+    default: undefined,
+  });
+
+  return selector({
+    key: 'onboardingToggleCount',
+    get: ({ get }) => get(atomForOnboardingToggleCount) === undefined 
+      ? storageOBToggleCount 
+      : get(atomForOnboardingToggleCount),
+    set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount),
+  })
 });

--- a/src/recoil.js
+++ b/src/recoil.js
@@ -41,5 +41,5 @@ const atomForOnboardingToggleCount = atom({
 export const onboardingToggleCount = selector({
   key: 'onboardingToggleCount',
   get: ({ get }) => get(atomForOnboardingToggleCount),
-  set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount)}
-);
+  set: ({ set }, newCount) => set(atomForOnboardingToggleCount, newCount),
+});

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -9,7 +9,6 @@ import {
   Button
 } from 'react-native';
 import * as Linking from 'expo-linking';
-import * as Updates from 'expo-updates';
 
 import Login from '../components/Login';
 import Colors from '../constants/Colors';

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -6,8 +6,10 @@ import {
   StatusBar,
   ActivityIndicator,
   Text,
+  Button
 } from 'react-native';
 import * as Linking from 'expo-linking';
+import * as Updates from 'expo-updates';
 
 import Login from '../components/Login';
 import Colors from '../constants/Colors';
@@ -25,6 +27,7 @@ const LoginScreen = () => (
       <Suspense fallback={<View style={styles.activityIndicator}><ActivityIndicator /></View>}>
         <OnboardingToggleButton />
       </Suspense>
+      <Button title="Reset Async Storage" onPress={() => Updates.reloadAsync()} />
       <View style={styles.vermonsterContainer}>
         <Text style={styles.companyText}>Powered by</Text>
         <Text style={styles.companyText} onPress={() => Linking.openURL('http://vermonster.com')}>Vermonster LLC</Text>

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -6,7 +6,6 @@ import {
   StatusBar,
   ActivityIndicator,
   Text,
-  Button
 } from 'react-native';
 import * as Linking from 'expo-linking';
 
@@ -26,7 +25,6 @@ const LoginScreen = () => (
       <Suspense fallback={<View style={styles.activityIndicator}><ActivityIndicator /></View>}>
         <OnboardingToggleButton />
       </Suspense>
-      <Button title="Reset Async Storage" onPress={() => Updates.reloadAsync()} />
       <View style={styles.vermonsterContainer}>
         <Text style={styles.companyText}>Powered by</Text>
         <Text style={styles.companyText} onPress={() => Linking.openURL('http://vermonster.com')}>Vermonster LLC</Text>

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const KEYS = {
   IS_ONBOARDING_COMPLETE: 'IS_ONBOARDING_COMPLETE',
+  ONBOARDING_TOGGLE_COUNT: 'ONBOARDING_TOGGLE_COUNT'
 };
 
 const setOnboardingState = async (isCompleted) => {
@@ -26,7 +27,31 @@ const getOnboardingState = async () => {
   return null;
 };
 
+const setOnboardingToggleCount = async (count) => {
+  try {
+    AsyncStorage.setItem(KEYS.ONBOARDING_TOGGLE_COUNT, JSON.stringify(count));
+  } catch (e) {
+    console.warn('AsyncStorage "setOnboardingState" failed.'); // eslint-disable-line no-console
+  }
+  return null;
+};
+
+const getOnboardingToggleCount = async () => {
+  try {
+    const value = await AsyncStorage.getItem(KEYS.ONBOARDING_TOGGLE_COUNT);
+    if (value) {
+      return JSON.parse(value);
+    }
+    return value;
+  } catch (e) {
+    console.warn('AsyncStorage "getOnboardingState" failed.'); // eslint-disable-line no-console
+  }
+  return null;
+};
+
 export default {
   getOnboardingState,
   setOnboardingState,
+  setOnboardingToggleCount,
+  getOnboardingToggleCount
 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const KEYS = {
   IS_ONBOARDING_COMPLETE: 'IS_ONBOARDING_COMPLETE',
-  ONBOARDING_TOGGLE_COUNT: 'ONBOARDING_TOGGLE_COUNT'
+  ONBOARDING_TOGGLE_COUNT: 'ONBOARDING_TOGGLE_COUNT',
 };
 
 const setOnboardingState = async (isCompleted) => {
@@ -53,5 +53,5 @@ export default {
   getOnboardingState,
   setOnboardingState,
   setOnboardingToggleCount,
-  getOnboardingToggleCount
+  getOnboardingToggleCount,
 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -42,7 +42,7 @@ const getOnboardingToggleCount = async () => {
     if (value) {
       return JSON.parse(value);
     }
-    return value;
+    return 0;
   } catch (e) {
     console.warn('AsyncStorage "getOnboardingState" failed.'); // eslint-disable-line no-console
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,10 +1834,32 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
+"@expo/config-plugins@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-2.0.2.tgz#5abf85ecbf81ea16d040c2c84b1b57d1111bce86"
+  integrity sha512-kaTfzLfg9sjy9uAHq708FVqC2hlVQyzCmrCsnfRguk2d+5V9ZyCVdMPiDdAIKHtWCPygIPNmlIP4FYQ093RNzQ==
+  dependencies:
+    "@expo/config-types" "^41.0.0"
+    "@expo/json-file" "8.2.30"
+    "@expo/plist" "0.0.13"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "^0.4.23"
+
 "@expo/config-types@^40.0.0-beta.2":
   version "40.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.2.tgz#4fea4ef5654d02218b02b0b3772529a9ce5b0471"
   integrity sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg==
+
+"@expo/config-types@^41.0.0":
+  version "41.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-41.0.0.tgz#ffe1444c6c26e0e3a8f7149b4afe486e357536d1"
+  integrity sha512-Ax0pHuY5OQaSrzplOkT9DdpdmNzaVDnq9VySb4Ujq7UJ4U4jriLy8u93W98zunOXpcu0iiKubPsqD6lCiq0pig==
 
 "@expo/config@4.0.0":
   version "4.0.0"
@@ -1850,6 +1872,26 @@
     "@babel/preset-typescript" "~7.12.13"
     "@expo/config-plugins" "2.0.0"
     "@expo/config-types" "^40.0.0-beta.2"
+    "@expo/json-file" "8.2.30"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    slugify "^1.3.4"
+
+"@expo/config@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-4.0.2.tgz#4db8632c3b893862adb6be076e0d51e577fa5a7d"
+  integrity sha512-zKKWt6Qs2lJLSwp8NeBCQ+iAPuKYkRJB6PZZJFIXaXD9AC5uJYSElUG+HVfy73se4KF/4JjndOWXWZEkCAivxw==
+  dependencies:
+    "@babel/core" "7.9.0"
+    "@babel/plugin-proposal-class-properties" "~7.12.13"
+    "@babel/preset-env" "~7.12.13"
+    "@babel/preset-typescript" "~7.12.13"
+    "@expo/config-plugins" "2.0.2"
+    "@expo/config-types" "^41.0.0"
     "@expo/json-file" "8.2.30"
     fs-extra "9.0.0"
     getenv "^1.0.0"
@@ -1912,20 +1954,6 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/configure-splash-screen@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.4.0.tgz#dad43fccae4525e32ec25d22c7338b2c3cbf6170"
-  integrity sha512-IDPnr2/DW1tYpDHqedFYNCDzRTf9HYinWFQ7fOelNZLuOCMoErLbSStA5zfkv46o69AgcCpteqgKHSoxsIBz5g==
-  dependencies:
-    color-string "^1.5.3"
-    commander "^5.1.0"
-    fs-extra "^9.0.0"
-    glob "^7.1.6"
-    lodash "^4.17.15"
-    pngjs "^5.0.0"
-    xcode "^3.0.0"
-    xml-js "^1.6.11"
-
 "@expo/image-utils@0.3.10":
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.10.tgz#bdb9d6a2a7280680dd56d7f9dd283863b58d1e1e"
@@ -1935,23 +1963,6 @@
     chalk "^4.0.0"
     fs-extra "9.0.0"
     getenv "0.7.0"
-    jimp "0.12.1"
-    mime "^2.4.4"
-    node-fetch "^2.6.0"
-    parse-png "^2.1.0"
-    resolve-from "^5.0.0"
-    semver "7.3.2"
-    tempy "0.3.0"
-
-"@expo/image-utils@0.3.14":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.14.tgz#eea0d59c5845e8b19504011c20afd837c5d044c5"
-  integrity sha512-n+JkLZ71CWuNKLVVsPTzMGRwmbeKiVQw/2b99Ro7znCKzJy3tyE5T2C6WBvYh/5h/hjg8TqEODjXXWucRIzMXA==
-  dependencies:
-    "@expo/spawn-async" "1.5.0"
-    chalk "^4.0.0"
-    fs-extra "9.0.0"
-    getenv "^1.0.0"
     jimp "0.12.1"
     mime "^2.4.4"
     node-fetch "^2.6.0"
@@ -1980,6 +1991,16 @@
     fs-extra "9.0.0"
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
+
+"@expo/metro-config@^0.1.16":
+  version "0.1.72"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.72.tgz#f4d9a7e4a512d76c7427d4ae2fe24fc8ef54ae90"
+  integrity sha512-PvWn5DZCV6hNYA9CTOBWEfwb9FCjyQCiyYnmxjsT0k9eplIBGTtfy74uIOd0SdDdCTPCgCO8SMyabc+Qg599xg==
+  dependencies:
+    "@expo/config" "4.0.2"
+    chalk "^4.1.0"
+    getenv "^1.0.0"
+    metro-react-native-babel-transformer "^0.59.0"
 
 "@expo/metro-config@^0.1.70":
   version "0.1.70"
@@ -5739,18 +5760,6 @@ glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.6:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,6 +1912,20 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
+"@expo/configure-splash-screen@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.4.0.tgz#dad43fccae4525e32ec25d22c7338b2c3cbf6170"
+  integrity sha512-IDPnr2/DW1tYpDHqedFYNCDzRTf9HYinWFQ7fOelNZLuOCMoErLbSStA5zfkv46o69AgcCpteqgKHSoxsIBz5g==
+  dependencies:
+    color-string "^1.5.3"
+    commander "^5.1.0"
+    fs-extra "^9.0.0"
+    glob "^7.1.6"
+    lodash "^4.17.15"
+    pngjs "^5.0.0"
+    xcode "^3.0.0"
+    xml-js "^1.6.11"
+
 "@expo/image-utils@0.3.10":
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.10.tgz#bdb9d6a2a7280680dd56d7f9dd283863b58d1e1e"
@@ -1921,6 +1935,23 @@
     chalk "^4.0.0"
     fs-extra "9.0.0"
     getenv "0.7.0"
+    jimp "0.12.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
+
+"@expo/image-utils@0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.14.tgz#eea0d59c5845e8b19504011c20afd837c5d044c5"
+  integrity sha512-n+JkLZ71CWuNKLVVsPTzMGRwmbeKiVQw/2b99Ro7znCKzJy3tyE5T2C6WBvYh/5h/hjg8TqEODjXXWucRIzMXA==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
     jimp "0.12.1"
     mime "^2.4.4"
     node-fetch "^2.6.0"
@@ -5149,6 +5180,15 @@ expo-status-bar@~1.0.3:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.3.tgz#62b4d6145680abd43ba6ecfa465f835e88bf6263"
   integrity sha512-/Orgla1nkIrfswNHbuAOTbPVq0g3+GrhoQVk7MRafY2dwrFLgXhaPExS+eN2hpmzqPv2LG5cqAZDCQUAjmZYBQ==
 
+expo-updates@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.4.2.tgz#15862bc209fa3fb98d3fa16b7aac4edfcc33f182"
+  integrity sha512-89bvwemgmWWPGAHHnzSFCryWW3TmPNozcShwi7976KAlNcXM7Aitv7uifxtkdBt85TECFm5N6LY278psjyt8Dg==
+  dependencies:
+    "@expo/metro-config" "^0.1.16"
+    fbemitter "^2.1.1"
+    uuid "^3.4.0"
+
 expo@~40.0.0:
   version "40.0.0"
   resolved "https://registry.yarnpkg.com/expo/-/expo-40.0.0.tgz#6caf03587532cd18b482991332a8b75eeca2fcb7"
@@ -5699,6 +5739,18 @@ glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
~~on top of #176~~ merged
- Create temp Onboarding Toggle Counter and store count in Async Storage
- Clear Async Storage `onboardingState` and `onboardingToggleCount` on button click
- Intentionally verbose recoil selectors/atoms instead of consolidating with other recoil onboarding state so it's easier to cut out later.

https://user-images.githubusercontent.com/45667486/119698224-0a3d8680-be1f-11eb-93cc-e35a8cd6b71a.mov

